### PR TITLE
Map feature codes to layers

### DIFF
--- a/lib/streams/layerMappingStream.js
+++ b/lib/streams/layerMappingStream.js
@@ -1,0 +1,27 @@
+var through2 = require('through2');
+
+function featureCodeToLayer(featureCode) {
+  switch (featureCode) {
+      case 'ADM1':
+          return 'region';
+      case 'ADM2':
+          return 'county';
+      case 'ADMD':
+          return 'locality';
+      default:
+          return 'venue';
+  }
+}
+
+function create() {
+  return through2.obj(function(data, enc, next) {
+    data.layer = featureCodeToLayer(data.feature_code);
+
+    next(null, data);
+  });
+}
+
+module.exports = {
+  featureCodeToLayer: featureCodeToLayer,
+  create: create
+};

--- a/lib/streams/peliasDocGenerator.js
+++ b/lib/streams/peliasDocGenerator.js
@@ -12,7 +12,8 @@ module.exports.create = function() {
   return through2.obj(function(data, enc, next) {
     var record;
     try {
-      record = new Document( 'geonames', 'venue', data._id )
+      var layer = data.layer || 'venue';
+      record = new Document( 'geonames', layer, data._id )
         .setName( 'default', data.name.trim() )
         .setCentroid({
           lat: data.latitude,

--- a/lib/tasks/import.js
+++ b/lib/tasks/import.js
@@ -5,6 +5,7 @@ var dbclient = require('pelias-dbclient');
 var model = require( 'pelias-model' );
 
 var adminLookupMetaStream = require('../streams/adminLookupMetaStream');
+var layerMappingStream = require( '../streams/layerMappingStream');
 var peliasDocGenerator = require( '../streams/peliasDocGenerator');
 
 module.exports = function( sourceStream, endStream, config ){
@@ -13,6 +14,7 @@ module.exports = function( sourceStream, endStream, config ){
 
   var pipeline = sourceStream
     .pipe( geonames.pipeline )
+    .pipe( layerMappingStream.create() )
     .pipe( peliasDocGenerator.create() );
 
   if( config.imports.geonames.adminLookup ){

--- a/test/data/expected.json
+++ b/test/data/expected.json
@@ -79040,7 +79040,7 @@
   },
   {
     "_index": "pelias",
-    "_type": "venue",
+    "_type": "region",
     "_id": "7535954",
     "data": {
       "name": {
@@ -79085,7 +79085,7 @@
         "admin"
       ],
       "source": "geonames",
-      "layer": "venue",
+      "layer": "region",
       "source_id": "7535954",
       "alpha3": "SGP",
       "admin0": "Singapore",
@@ -79094,7 +79094,7 @@
   },
   {
     "_index": "pelias",
-    "_type": "venue",
+    "_type": "region",
     "_id": "7535955",
     "data": {
       "name": {
@@ -79139,7 +79139,7 @@
         "admin"
       ],
       "source": "geonames",
-      "layer": "venue",
+      "layer": "region",
       "source_id": "7535955",
       "alpha3": "SGP",
       "admin0": "Singapore",
@@ -79148,7 +79148,7 @@
   },
   {
     "_index": "pelias",
-    "_type": "venue",
+    "_type": "region",
     "_id": "7535956",
     "data": {
       "name": {
@@ -79193,7 +79193,7 @@
         "admin"
       ],
       "source": "geonames",
-      "layer": "venue",
+      "layer": "region",
       "source_id": "7535956",
       "alpha3": "SGP",
       "admin0": "Singapore",
@@ -79202,7 +79202,7 @@
   },
   {
     "_index": "pelias",
-    "_type": "venue",
+    "_type": "region",
     "_id": "7535957",
     "data": {
       "name": {
@@ -79247,7 +79247,7 @@
         "admin"
       ],
       "source": "geonames",
-      "layer": "venue",
+      "layer": "region",
       "source_id": "7535957",
       "alpha3": "SGP",
       "admin0": "Singapore",
@@ -79256,7 +79256,7 @@
   },
   {
     "_index": "pelias",
-    "_type": "venue",
+    "_type": "region",
     "_id": "7535958",
     "data": {
       "name": {
@@ -79301,7 +79301,7 @@
         "admin"
       ],
       "source": "geonames",
-      "layer": "venue",
+      "layer": "region",
       "source_id": "7535958",
       "alpha3": "SGP",
       "admin0": "Singapore",

--- a/test/streams/layerMappingStreamTest.js
+++ b/test/streams/layerMappingStreamTest.js
@@ -1,0 +1,55 @@
+var tape = require('tape');
+var event_stream = require('event-stream');
+
+var layerMappingStream = require('../../lib/streams/layerMappingStream');
+var featureCodeToLayer = layerMappingStream.featureCodeToLayer;
+
+function test_stream(input, testedStream, callback) {
+    var input_stream = event_stream.readArray(input);
+    var destination_stream = event_stream.writeArray(callback);
+
+    input_stream.pipe(testedStream).pipe(destination_stream);
+}
+
+tape('featureCodeToLayer', function(test) {
+  test.test('unusual feature code should map to venue', function(t) {
+    t.equal('venue', featureCodeToLayer('CNL'), 'all codes not handled map to venue');
+    t.end();
+  });
+
+  test.test('ADM1 maps to region', function(t) {
+    t.equal('region', featureCodeToLayer('ADM1'), 'Geonames ADM1 maps to region layer');
+    t.end();
+  });
+
+  test.test('ADM2 maps to county', function(t) {
+    t.equal('county', featureCodeToLayer('ADM2'), 'Geonames ADM2 maps to county layer');
+    t.end();
+  });
+
+  test.test('ADMD maps to locality', function(t) {
+    t.equal('locality', featureCodeToLayer('ADMD'), 'Geonames ADMD maps to locality layer');
+    t.end();
+  });
+});
+
+tape('layerMappingStream', function(test) {
+  test.test('stream of raw Geonames entries has layers correctly mapped', function(t) {
+    var input = [
+      { feature_code: 'OCN' },
+      { feature_code: 'ADM1' },
+      { feature_code: 'POOL' },
+      { feature_code: 'ADMD' } ];
+    var stream = layerMappingStream.create();
+
+    test_stream(input, stream, function(err, results) {
+      var actual = results.map(function(doc) {
+        return doc.layer;
+      });
+
+      var expected = [ 'venue', 'region', 'venue', 'locality' ];
+      test.deepEqual(actual, expected, 'layers mapped correctly');
+      t.end();
+    });
+  });
+});

--- a/test/units.js
+++ b/test/units.js
@@ -1,1 +1,2 @@
 require ('./streams/peliasDocGeneratorTest.js');
+require ('./streams/layerMappingStreamTest.js');


### PR DESCRIPTION
This PR adds a new stream that looks at the Geonames [feature code](http://www.geonames.org/export/codes.html) to properly set the layer of Geonames records. Right now it only supports mapping to the following layers:

* region (states in the USA)
* county
* locality

If anyone has suggestions for feature codes that map to other layers, let me know, as they're quite easy to add.

Fixes #31 