### PR TITLE
Filter unwanted fcodes

### DIFF
--- a/lib/streams/featureCodeFilterStream.js
+++ b/lib/streams/featureCodeFilterStream.js
@@ -1,0 +1,32 @@
+var filter = require('through2-filter');
+var _ = require( 'lodash' );
+
+var unwantedFcodes = [
+  'RGNE', // economic regions. consists of multiple cities and is unwanted for geocoding
+  'ADM1H', // historical
+  'ADM2H', // historical
+  'ADM3H', // historical
+  'ADM4H', // historical
+  'ADMDH', // historical
+  'PCLH',  // historical
+  'RGNH',  // historical
+  'PPLCH', // historical
+  'PPLH',  // historical
+  'PPLQ',  // abandoned places
+  'PPLW',  // destroyed place
+  'ZN',    // large multi-state regions
+  'CONT',  // contenents (currently not supported)
+];
+
+function filterRecord(data) {
+  return !_.includes(unwantedFcodes, data.feature_code);
+}
+
+function create() {
+  return filter.obj(filterRecord);
+}
+
+module.exports = {
+  filterRecord: filterRecord,
+  create: create
+};

--- a/lib/tasks/import.js
+++ b/lib/tasks/import.js
@@ -3,6 +3,7 @@ var peliasConfig = require( 'pelias-config' );
 var dbclient = require('pelias-dbclient');
 var model = require( 'pelias-model' );
 
+var featureCodeFilterStream = require('../streams/featureCodeFilterStream');
 var adminLookupStream = require('../streams/adminLookupStream');
 var layerMappingStream = require( '../streams/layerMappingStream');
 var peliasDocGenerator = require( '../streams/peliasDocGenerator');
@@ -12,6 +13,7 @@ module.exports = function( sourceStream, endStream, config ){
   config = config || peliasConfig.generate();
 
   return sourceStream.pipe( geonames.pipeline )
+    .pipe( featureCodeFilterStream.create() )
     .pipe( layerMappingStream.create() )
     .pipe( peliasDocGenerator.create() )
     .pipe( adminLookupStream.create(config.imports.geonames.adminLookup) )

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "progress": "^1.1.5",
     "progress-stream": "^1.2.0",
     "request": "^2.34.0",
-    "through2": "^2.0.1"
+    "through2": "^2.0.1",
+    "through2-filter": "^2.0.0"
   },
   "devDependencies": {
     "deep-diff": "^0.3.3",

--- a/test/data/expected.json
+++ b/test/data/expected.json
@@ -77731,61 +77731,6 @@
   {
     "_index": "pelias",
     "_type": "venue",
-    "_id": "6951473",
-    "data": {
-      "name": {
-        "default": "Chijmes"
-      },
-      "phrase": {
-        "default": "Chijmes"
-      },
-      "parent": {
-        "country": [],
-        "country_a": [],
-        "country_id": [],
-        "macroregion": [],
-        "macroregion_a": [],
-        "macroregion_id": [],
-        "region": [],
-        "region_a": [],
-        "region_id": [],
-        "macrocounty": [],
-        "macrocounty_a": [],
-        "macrocounty_id": [],
-        "county": [],
-        "county_a": [],
-        "county_id": [],
-        "locality": [],
-        "locality_a": [],
-        "locality_id": [],
-        "localadmin": [],
-        "localadmin_a": [],
-        "localadmin_id": [],
-        "neighbourhood": [],
-        "neighbourhood_a": [],
-        "neighbourhood_id": []
-      },
-      "address": {},
-      "center_point": {
-        "lon": 103.852,
-        "lat": 1.29514
-      },
-      "category": [
-        "finance",
-        "professional",
-        "government",
-        "admin"
-      ],
-      "source": "geonames",
-      "layer": "venue",
-      "source_id": "6951473",
-      "alpha3": "SGP",
-      "admin0": "Singapore"
-    }
-  },
-  {
-    "_index": "pelias",
-    "_type": "venue",
     "_id": "6951474",
     "data": {
       "name": {

--- a/test/streams/featureCodeFilterStream.js
+++ b/test/streams/featureCodeFilterStream.js
@@ -1,0 +1,18 @@
+var tape = require('tape');
+
+var featureCodeFilterStream = require ('../../lib/streams/featureCodeFilterStream');
+var filterRecord = featureCodeFilterStream.filterRecord;
+
+tape('feature code filters', function(test) {
+  test.test('filtered out records will be removed', function(t) {
+    var record = { feature_code: 'RGNE' };
+    t.notOk(filterRecord(record), 'RGNE is filtered out');
+    t.end();
+  });
+
+  test.test('good records are not removed', function(t) {
+    var record = { feature_code: 'ADM1' };
+    t.ok(filterRecord(record), 'ADM1 is not filtered out');
+    t.end();
+  });
+});

--- a/test/units.js
+++ b/test/units.js
@@ -1,2 +1,3 @@
 require ('./streams/peliasDocGeneratorTest.js');
 require ('./streams/layerMappingStreamTest.js');
+require ('./streams/featureCodeFilterStream');


### PR DESCRIPTION
Filter out Geonames feature codes that correspond to historical, destroyed, and other records not useful for geocoding.

Fixes #42