### PR TITLE
Add country specific mappings

### DIFF
--- a/lib/streams/layerMappingStream.js
+++ b/lib/streams/layerMappingStream.js
@@ -41,6 +41,15 @@ function featureCodeToLayerGB(featureCode) {
   }
 }
 
+function featureCodeToLayerES(featureCode) {
+  switch (featureCode) {
+      case 'ADM1':
+          return 'macroregion';
+      default:
+          return featureCodeToLayerDefault(featureCode);
+  }
+}
+
 function featureCodeToLayerFR(featureCode) {
   switch (featureCode) {
       case 'RGN':
@@ -54,6 +63,8 @@ function featureCodeToLayer(featureCode, countryCode) {
   switch (countryCode) {
       case 'GB':
           return featureCodeToLayerGB(featureCode);
+      case 'ES':
+          return featureCodeToLayerES(featureCode);
       case 'FR':
           return featureCodeToLayerFR(featureCode);
       default:

--- a/lib/streams/layerMappingStream.js
+++ b/lib/streams/layerMappingStream.js
@@ -41,10 +41,21 @@ function featureCodeToLayerGB(featureCode) {
   }
 }
 
+function featureCodeToLayerFR(featureCode) {
+  switch (featureCode) {
+      case 'RGN':
+          return 'macroregion';
+      default:
+          return featureCodeToLayerDefault(featureCode);
+  }
+}
+
 function featureCodeToLayer(featureCode, countryCode) {
   switch (countryCode) {
       case 'GB':
           return featureCodeToLayerGB(featureCode);
+      case 'FR':
+          return featureCodeToLayerFR(featureCode);
       default:
           return featureCodeToLayerDefault(featureCode);
   }

--- a/lib/streams/layerMappingStream.js
+++ b/lib/streams/layerMappingStream.js
@@ -1,6 +1,6 @@
 var through2 = require('through2');
 
-function featureCodeToLayer(featureCode) {
+function featureCodeToLayerDefault(featureCode) {
   switch (featureCode) {
       case 'PCLI':
           return 'country';
@@ -32,9 +32,27 @@ function featureCodeToLayer(featureCode) {
   }
 }
 
+function featureCodeToLayerGB(featureCode) {
+  switch (featureCode) {
+      case 'ADM1':
+          return 'macroregion';
+      default:
+          return featureCodeToLayerDefault(featureCode);
+  }
+}
+
+function featureCodeToLayer(featureCode, countryCode) {
+  switch (countryCode) {
+      case 'GB':
+          return featureCodeToLayerGB(featureCode);
+      default:
+          return featureCodeToLayerDefault(featureCode);
+  }
+}
+
 function create() {
   return through2.obj(function(data, enc, next) {
-    data.layer = featureCodeToLayer(data.feature_code);
+    data.layer = featureCodeToLayer(data.feature_code, data.country_code);
 
     next(null, data);
   });

--- a/lib/streams/layerMappingStream.js
+++ b/lib/streams/layerMappingStream.js
@@ -59,6 +59,15 @@ function featureCodeToLayerFR(featureCode) {
   }
 }
 
+function featureCodeToLayerIT(featureCode) {
+  switch (featureCode) {
+      case 'ADM1':
+          return 'macroregion';
+      default:
+          return featureCodeToLayerDefault(featureCode);
+  }
+}
+
 function featureCodeToLayer(featureCode, countryCode) {
   switch (countryCode) {
       case 'GB':
@@ -67,6 +76,8 @@ function featureCodeToLayer(featureCode, countryCode) {
           return featureCodeToLayerES(featureCode);
       case 'FR':
           return featureCodeToLayerFR(featureCode);
+      case 'IT':
+          return featureCodeToLayerIT(featureCode);
       default:
           return featureCodeToLayerDefault(featureCode);
   }

--- a/test/streams/layerMappingStreamTest.js
+++ b/test/streams/layerMappingStreamTest.js
@@ -13,22 +13,22 @@ function test_stream(input, testedStream, callback) {
 
 tape('featureCodeToLayer', function(test) {
   test.test('unusual feature code should map to venue', function(t) {
-    t.equal('venue', featureCodeToLayer('CNL'), 'all codes not handled map to venue');
+    t.equal(featureCodeToLayer('CNL'), 'venue', 'all codes not handled map to venue');
     t.end();
   });
 
   test.test('ADM1 maps to region', function(t) {
-    t.equal('region', featureCodeToLayer('ADM1'), 'Geonames ADM1 maps to region layer');
+    t.equal(featureCodeToLayer('ADM1'), 'region', 'Geonames ADM1 maps to region layer');
     t.end();
   });
 
   test.test('ADM2 maps to county', function(t) {
-    t.equal('county', featureCodeToLayer('ADM2'), 'Geonames ADM2 maps to county layer');
+    t.equal(featureCodeToLayer('ADM2'), 'county', 'Geonames ADM2 maps to county layer');
     t.end();
   });
 
   test.test('ADMD maps to localadmin', function(t) {
-    t.equal('localadmin', featureCodeToLayer('ADMD'), 'Geonames ADMD maps to localadmin layer');
+    t.equal(featureCodeToLayer('ADMD'), 'localadmin', 'Geonames ADMD maps to localadmin layer');
     t.end();
   });
 });

--- a/test/streams/layerMappingStreamTest.js
+++ b/test/streams/layerMappingStreamTest.js
@@ -38,6 +38,11 @@ tape('country specific featureCodes', function(test) {
     t.equal(featureCodeToLayer('ADM1', 'GB'), 'macroregion', 'Geonames ADM1 maps to macroregion in Great Britain');
     t.end();
   });
+
+  test.test('RGN in FR maps to macroregion', function(t) {
+    t.equal(featureCodeToLayer('RGN', 'FR'), 'macroregion', 'Geonames RGN maps to macroregion in France');
+    t.end();
+  });
 });
 
 tape('layerMappingStream', function(test) {

--- a/test/streams/layerMappingStreamTest.js
+++ b/test/streams/layerMappingStreamTest.js
@@ -43,6 +43,11 @@ tape('country specific featureCodes', function(test) {
     t.equal(featureCodeToLayer('RGN', 'FR'), 'macroregion', 'Geonames RGN maps to macroregion in France');
     t.end();
   });
+
+  test.test('ADM1 in ES maps to macroregion', function(t) {
+    t.equal(featureCodeToLayer('ADM1', 'ES'), 'macroregion', 'Geonames ADM1 maps to macroregion in Spain');
+    t.end();
+  });
 });
 
 tape('layerMappingStream', function(test) {

--- a/test/streams/layerMappingStreamTest.js
+++ b/test/streams/layerMappingStreamTest.js
@@ -48,6 +48,11 @@ tape('country specific featureCodes', function(test) {
     t.equal(featureCodeToLayer('ADM1', 'ES'), 'macroregion', 'Geonames ADM1 maps to macroregion in Spain');
     t.end();
   });
+
+  test.test('ADM1 in IT maps to macroregion', function(t) {
+    t.equal(featureCodeToLayer('ADM1', 'IT'), 'macroregion', 'Geonames ADM1 maps to macroregion in Italy');
+    t.end();
+  });
 });
 
 tape('layerMappingStream', function(test) {

--- a/test/streams/layerMappingStreamTest.js
+++ b/test/streams/layerMappingStreamTest.js
@@ -33,6 +33,13 @@ tape('featureCodeToLayer', function(test) {
   });
 });
 
+tape('country specific featureCodes', function(test) {
+  test.test('ADM1 in GB maps to macroregion', function(t) {
+    t.equal(featureCodeToLayer('ADM1', 'GB'), 'macroregion', 'Geonames ADM1 maps to macroregion in Great Britain');
+    t.end();
+  });
+});
+
 tape('layerMappingStream', function(test) {
   test.test('stream of raw Geonames entries has layers correctly mapped', function(t) {
     var input = [


### PR DESCRIPTION
Last week we discovered that Geonames admin regions are not consistent globally (mostly because this may be impossible for any admin heirarchy system), but they appear to be ok within a single country.

I looked at the macroregions in Great Britain, Spain, Italy, and France, and they had a 1 to 1 mapping to a single admin code in each country. This PR sets up a framework where we can define a partial mapping in any country going forward.

This, combined with pelias/api#461, will allow us to have the right label for Wales!
Fixes #49 