### PR TITLE
Update travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,30 @@
 sudo: false
 language: node_js
+cache:
+  directories:
+    - node_modules
+notifications:
+  email: false
 node_js:
-  - 0.10
   - 0.12
-  - 4.4
-  - 5.8
+  - 4
+  - 5
+  - 6
 matrix:
+    fast_finish: true
     allow_failures:
-        - node_js: 4.4
-        - node_js: 5.8
+        - node_js: 6
 env:
   global:
     - CXX=g++-4.8
-  matrix:
-    - TEST_SUITE=units
-    - TEST_SUITE=functional
-script: "npm run $TEST_SUITE"
+script: "npm run travis"
 addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
     packages:
       - g++-4.8
+before_install:
+  - npm i -g npm@^2.0.0
+before_script:
+  - npm prune

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "lint": "jshint .",
     "postinstall": "npm run download_metadata",
     "test": "npm run units",
+    "travis": "npm test && npm run functional",
     "units": "node test/units.js | tap-dot",
     "validate": "npm ls"
   },

--- a/package.json
+++ b/package.json
@@ -7,12 +7,12 @@
   "license": "MIT",
   "scripts": {
     "download_metadata": "mkdir -p metadata && ./bin/pelias-geonames -m",
-    "postinstall": "npm run download_metadata",
-    "test": "npm run units",
-    "units": "node test/units.js | tap-dot",
     "functional": "node test/functional.js | tap-dot",
     "import": "./bin/pelias-geonames",
     "lint": "jshint .",
+    "postinstall": "npm run download_metadata",
+    "test": "npm run units",
+    "units": "node test/units.js | tap-dot",
     "validate": "npm ls"
   },
   "bin": {


### PR DESCRIPTION
The usual updates that we have been slowly rolling out to other repos:

* Add Node 6, drop Node 0.10
* Only specify major versions for Node, so the latest minor release gets used automatically
* Cache `node_modules` dir to speed things up
* Add a `travis` NPM script that runs the unit tests _and_ end-to-end tests. this speeds things up by reducing the number of times a new Travis worker has to start up
* Reorder all the NPM scripts in the `package.json` file alphabetically