### PR TITLE
fix: add missing ADM3 tag to layer mapping

### DIFF
--- a/lib/streams/layerMappingStream.js
+++ b/lib/streams/layerMappingStream.js
@@ -11,6 +11,7 @@ function featureCodeToLayerDefault(featureCode) {
           return 'county';
       case 'ADMD':
           return 'localadmin';
+      case 'ADM3':
       case 'PPL':
       case 'PPLA':
       case 'PPLA2':


### PR DESCRIPTION
We were missing ADM3 in the layer mapping which caused a lot of localities to show up as venues: 88181 to be exact! 😿 

Fixes #119 