### PR TITLE
Add verify script

### DIFF
--- a/bin/verify.js
+++ b/bin/verify.js
@@ -1,0 +1,25 @@
+const unzipper = require('unzipper');
+const sink = require('through2-sink');
+
+const config = require('pelias-config').generate();
+const resolvers = require( '.././lib/tasks/resolvers' );
+
+console.log('verifying local file');
+
+const isocode = config.imports.geonames.countryCode;
+const filename = isocode === 'ALL' ? 'allCountries' : isocode;
+const fileStream = resolvers.getLocalFileStream(filename);
+
+const unzipStream = unzipper.Parse();
+
+unzipStream.on('entry', function(entry) {
+  console.log(entry.props);
+
+  // pipe every file to a stream that does nothing
+  entry.pipe(sink(function() {}));
+}).on('error', function(err) {
+  console.error(err);
+  process.exit(1);
+});
+
+fileStream.pipe(unzipStream);

--- a/lib/tasks/resolvers.js
+++ b/lib/tasks/resolvers.js
@@ -7,15 +7,29 @@ var fs = require('fs'),
 var settings = require('pelias-config').generate();
 var basepath = settings.imports.geonames.datapath;
 
-module.exports.selectSource = function(filename) {
+function getLocalFileStream(filename) {
   var localFileName = util.format( '%s/%s.zip', basepath, filename );
-  var remoteFilePath = util.format( 'http://download.geonames.org/export/dump/%s.zip', filename );
-
   if( fs.existsSync( localFileName ) ){
     logger.info( 'reading datafile from disk at:', localFileName );
     return fs.createReadStream( localFileName);
   } else {
-    logger.info( 'streaming datafile from:', remoteFilePath );
-    return request.get( remoteFilePath );
+    return undefined;
   }
+}
+
+function getRemoteFileStream(filename) {
+  var remoteFilePath = util.format( 'http://download.geonames.org/export/dump/%s.zip', filename );
+
+  logger.info( 'streaming datafile from:', remoteFilePath );
+  return request.get( remoteFilePath );
+}
+
+function selectSource(filename) {
+  return getLocalFileStream(filename) || getRemoteFileStream(filename);
+}
+
+module.exports = {
+  getLocalFileStream: getLocalFileStream,
+  getRemoteFileStream: getRemoteFileStream,
+  selectSource: selectSource
 };

--- a/package.json
+++ b/package.json
@@ -53,7 +53,9 @@
     "pelias-wof-admin-lookup": "2.11.0",
     "request": "^2.34.0",
     "through2": "^2.0.1",
-    "through2-filter": "^2.0.0"
+    "through2-filter": "^2.0.0",
+    "through2-sink": "^1.0.0",
+    "unzipper": "^0.8.3"
   },
   "devDependencies": {
     "deep-diff": "^0.3.3",


### PR DESCRIPTION
This adds a PR to verify the data downloaded for Geonames. Sometimes these zip files are incomplete or corrupt in a way that prevents the `unzipper` NPM module from reading them. By reading the zip file into a stream that does nothing, we should be able to catch them.