### PR TITLE
Increase Node.js memory limit

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "import": "npm run start",
     "lint": "jshint .",
     "postinstall": "npm run download_metadata",
-    "start": "node import.js",
+    "start": "node --max_old_space_size=4096 import.js",
     "test": "npm run units",
     "travis": "npm run check-dependencies && npm test && npm run functional",
     "units": "node test/units.js | tap-dot",


### PR DESCRIPTION
The admin lookup worker processes are starting to hit the default memory
limit. Increasing it gives us time to improve the admin lookup
architecture.

Connected to https://github.com/pelias/wof-admin-lookup/issues/117