### PR TITLE
Explicitly handle metadata in Docker and update Documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,5 +18,8 @@ ADD . $WORK
 # install npm dependencies
 RUN npm install
 
+# Explicitly download metadata (it will not be downloaded automatically in noninteractive sessions)
+RUN npm run download_metadata
+
 # run tests
 RUN npm test

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ import.
 git clone https://github.com/pelias/geonames
 cd geonames
 npm install
-npm run download_metadata
 ```
 
 ### Configuration
@@ -80,6 +79,12 @@ The data corresponding to the countryCode in the pelias config file will be down
 
 ### Updating Metadata
 
-The metadata is not shipped with the repo, to pull the latest metadata run
+The metadata is not shipped with the repo, however, during normal usagage running `npm install` will also trigger a script that updates the metadata.
 
-`npm run download_metadata`
+__However__ this hook will not trigger in non-interactive sessions such as many shell scripts. To explicitly download the metadata or refresh it (it changes very infrequently, perhaps every few months), run:
+
+```
+npm run download_metadata
+```
+
+The metadata _is_ packaged in our Docker images, so using an up to date docker image should guarantee recent enough metadata.


### PR DESCRIPTION
The mystery of metadata from https://github.com/pelias/geonames/issues/222 has been solved! It turns out npm postinstall hooks, which we use to download the metadata, do not fire when `DEBIAN_FRONTEND=noninteractive` is set in the shell, such as we do in our Docker [baseimage](https://github.com/pelias/dockerfiles/blob/master/baseimage/Dockerfile#L8).

This explains why the metadata downloads fine on local machines and in the Chef Mapzen Search environment, but not in Kubernetes. It also doesn't work in the Docker image in general.

This PR adds an explicit `npm run download_metadata` to the Dockerfile, so that the Docker images contain this metadata, solving any Docker or Kubernetes issues.

Additionally, it updates the readme to both clarify the situation in the metadata documentation section, and remove it from the main install instructions (since under normal interactive shell sessions it
is _not_ required and would just be an extra step).

Fixes https://github.com/pelias/geonames/issues/222
Connects https://github.com/pelias/geonames/pull/223