### PR TITLE
Disabling venues import 

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ The importer can be configured from your local [pelias-config](https://github.co
 	"imports": {
 		"geonames": {
 			"datapath": "/path/to/geonames/data",
-			"countryCode": "MX"
+			"countryCode": "MX",
+			"importVenues": "true | false"
 		}
 	}
 }
@@ -45,6 +46,7 @@ The following are all *optional*:
   * `datapath`: the path to geonames data. Defaults to a directory inside the importer.
   * `countryCode`: the two digit ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1)) country code
     for the country for which data will be downloaded and imported. Use `ALL` for all countries.
+  * `importVenues`: a boolean that gives to the importer the possibility to download or not the OSM venues. Default value is "true".
 
 #### Admin Lookup
 Pelias has the ability to compute the admin hierarchy (county, region, country, etc)

--- a/lib/streams/featureCodeFilterStream.js
+++ b/lib/streams/featureCodeFilterStream.js
@@ -1,5 +1,11 @@
+const config = require('pelias-config').generate();
 var filter = require('through2-filter');
 var _ = require( 'lodash' );
+var importVenues = true;
+
+if (_.has(config, 'imports.geonames.importVenues')) {
+  importVenues = config.imports.geonames.importVenues;
+}
 
 var unwantedFcodes = [
   'RGNE', // economic regions. consists of multiple cities and is unwanted for geocoding
@@ -18,7 +24,34 @@ var unwantedFcodes = [
   'CONT',  // contenents (currently not supported)
 ];
 
+// Feature codes corresponding to venues
+// http://www.geonames.org/export/codes.html
+var venuesFcodes = [
+  'ADMF','AGRF','AIRB','AIRF','AIRH','AIRP','AIRQ','AMTH','ANS','AQC','ARCH','ASTR',
+  'ASYL','ATHF','ATM','BANK','BCN','BDG','BDGQ','BLDG','BLDO','BP','BRKS','BRKW','BSTN',
+  'BTYD','BUR','BUSTN','BUSTP','CARN','CAVE','CH','CMP','CMPL','CMPLA','CMPMN',
+  'CMPO','CMPQ','CMPRF','CMTY','COMC','CRRL','CSNO','CSTL','CSTM','CTHSE','CTRA','CTRCM',
+  'CTRF','CTRM','CTRR','CTRS','CVNT','DAM','DAMQ','DAMSB','DARY','DCKD','DCKY','DIKE','DIP',
+  'DPOF','EST','ESTO','ESTR','ESTSG','ESTT','ESTX','FCL','FNDY','FRM','FRMQ','FRMS','FRMT',
+  'FT','FY','GATE','GDN','GHAT','GHSE','GOSP','GOVL','GRVE','HERM','HLT','HMSD','HSE','HSEC',
+  'HSP','HSPC','HSPD','HSPL','HSTS','HTL','HUT','HUTS','INSM','ITTR','JTY','LDNG','LEPC','LIBR',
+  'LNDF','LOCK','LTHSE','MALL','MAR','MFG','MFGB','MFGC','MFGCU','MFGLM','MFGM','MFGPH','MFGQ',
+  'MFGSG','MKT','ML','MLM','MLO','MLSG','MLSGQ','MLSW','MLWND','MLWTR','MN','MNAU','MNC','MNCR',
+  'MNCU','MNFE','MNMT','MNN','MNQ','MNQR','MOLE','MSQE','MSSN','MSSNQ','MSTY','MTRO','MUS','NOV',
+  'NSY','OBPT','OBS','OBSR','OILJ','OILQ','OILR','OILT','OILW','OPRA','PAL','PGDA','PIER','PKLT',
+  'PMPO','PMPW','PO','PP','PPQ','PRKGT','PRKHQ','PRN','PRNJ','PRNQ','PS','PSH','PSTB','PSTC','PSTP',
+  'PYR','PYRS','QUAY','RDCR','RECG','RECR','REST','RET','RHSE','RKRY','RLG','RLGR','RNCH',
+  'RSD','RSGNL','RSRT','RSTN','RSTNQ','RSTP','RSTPQ','RUIN','SCH','SCHA','SCHC','SCHL','SCHM',
+  'SCHN','SCHT','SECP','SHPF','SHRN','SHSE','SLCE','SNTR','SPA','SPLY','SQR','STBL','STDM',
+  'STNB','STNC','STNE','STNF','STNI','STNM','STNR','STNS','STNW','STPS','SWT','THTR','TMB',
+  'TMPL','TNKD','TOWR','TRANT','TRIG','TRMO','TWO','UNIP','UNIV','USGE','VETF','WALL','WALLA',
+  'WEIR','WHRF','WRCK','WTRW','ZNF','ZOO'
+]
+
 function filterRecord(data) {
+  if(!importVenues) {
+    unwantedFcodes = unwantedFcodes.concat(venuesFcodes);
+  }
   return !_.includes(unwantedFcodes, data.feature_code);
 }
 

--- a/test/streams/featureCodeFilterStream.js
+++ b/test/streams/featureCodeFilterStream.js
@@ -1,7 +1,24 @@
 var tape = require('tape');
-
+var proxyquire = require('proxyquire');
+var settings = require('pelias-config').generate();
 var featureCodeFilterStream = require ('../../lib/streams/featureCodeFilterStream');
 var filterRecord = featureCodeFilterStream.filterRecord;
+
+var fakeGeneratedConfig = {
+  imports: {
+    geonames: {
+      "datapath": "/path/to/geonames/data",
+      "countryCode": "MX",
+      importVenues: false,
+    }
+  }
+};
+
+var fakeConfig = {
+  generate: function fakeGenerate() {
+    return fakeGeneratedConfig;
+  }
+};
 
 tape('feature code filters', function(test) {
   test.test('filtered out records will be removed', function(t) {
@@ -13,6 +30,19 @@ tape('feature code filters', function(test) {
   test.test('good records are not removed', function(t) {
     var record = { feature_code: 'ADM1' };
     t.ok(filterRecord(record), 'ADM1 is not filtered out');
+    t.end();
+  });
+
+  test.test('poi records are not removed', function(t) {
+    var record = { feature_code: 'BANK' };
+    t.ok(filterRecord(record), 'BANK is not filtered out');
+    t.end();
+  });
+
+  test.test('poi records are removed', function(t) {
+    var record = { feature_code: 'BANK' };
+    var localFeatureCodeFilterStream = proxyquire('../../lib/streams/featureCodeFilterStream', {'pelias-config': fakeConfig});
+    t.notOk(localFeatureCodeFilterStream.filterRecord(record), 'BANK is filtered out');
     t.end();
   });
 });


### PR DESCRIPTION
We want the Geonames importer to be able to choose or not to download the Geonames venues.
We propose to manage this new ability with a new parameter 'importVenues' as described below.

The parameter 'importVenues' is defined in the 'pelias.json' file with the following key: 'imports.geonames.importVenues'.
To ensure backward compatibility this parameter is set to 'true' by default, thereby this new feature changes nowise the normal Pelias behavior.

You can squash & rebase the commits we did in the branch corresponding to this feature.