### PR TITLE
feat(docker): run as pelias user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,3 +23,6 @@ RUN npm run download_metadata
 
 # run tests
 RUN npm test
+
+# run as the pelias user
+USER pelias


### PR DESCRIPTION
This uses the work in https://github.com/pelias/baseimage/pull/2 to run processes as the `pelias` user. Running as a non-root user is ideal from a security perspective.