### PR TITLE
feat(test): Use test dedicated script to catch errors

### DIFF
--- a/bin/functional
+++ b/bin/functional
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# run tests with pipefail to avoid false passes
+# see https://github.com/pelias/pelias/issues/744
+set -euo pipefail
+
+NODE_ENV=test node test/functional.js | npx tap-dot

--- a/bin/units
+++ b/bin/units
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# run tests with pipefail to avoid false passes
+# see https://github.com/pelias/pelias/issues/744
+set -euo pipefail
+
+node test/units.js | npx tap-dot

--- a/package.json
+++ b/package.json
@@ -9,14 +9,14 @@
     "download_metadata": "mkdirp metadata && node bin/updateMetadata.js",
     "download": "node bin/downloadData.js",
     "countryCodes": "node bin/viewCountryCodes.js",
-    "functional": "NODE_ENV=test node test/functional.js | tap-dot",
+    "functional": "./bin/functional",
     "import": "npm run start",
     "lint": "jshint .",
     "postinstall": "npm run download_metadata",
     "start": "node --max_old_space_size=4096 import.js",
     "test": "NODE_ENV=test npm run units",
     "travis": "npm test && npm run functional",
-    "units": "node test/units.js | tap-dot",
+    "units": "./bin/units",
     "validate": "npm ls"
   },
   "repository": {


### PR DESCRIPTION
The way we were running our unit tests does not catch fatal errors in the unit test run, even though they return non-zero status codes.

By using a dedicated script to run the tests, with the `pipefail` option, we can catch them.

Connects https://github.com/pelias/pelias/issues/744