### PR TITLE
feat(filter): Remove RGN records

### DIFF
--- a/lib/streams/featureCodeFilterStream.js
+++ b/lib/streams/featureCodeFilterStream.js
@@ -2,7 +2,8 @@ var filter = require('through2-filter');
 var _ = require( 'lodash' );
 
 var unwantedFcodes = [
-  'RGNE', // economic regions. consists of multiple cities and is unwanted for geocoding
+  'RGN',   // large regions like 'Northern Europe' or 'Southern California' that don't fit well in admin hierarchies
+  'RGNE',  // economic regions. consists of multiple cities and is unwanted for geocoding
   'ADM1H', // historical
   'ADM2H', // historical
   'ADM3H', // historical


### PR DESCRIPTION
These records seem to correspond to large, non-administrative, regions such as 'Northern Europe' and 'Southern California'. They feel very subjective and don't map well into administrative hierarchies, often coming up in unexpected search results.

There are only about 2200 and after a brief skim it looks safe to remove them all.

Fixes https://github.com/pelias/geonames/issues/70