### PR TITLE
feat(logger): Use dbclient name functionality

### DIFF
--- a/lib/tasks/import.js
+++ b/lib/tasks/import.js
@@ -10,7 +10,7 @@ var peliasDocGenerator = require('../streams/peliasDocGenerator');
 var overrideLookedUpLocalityAndLocaladmin = require('../streams/overrideLookedUpLocalityAndLocaladmin');
 
 module.exports = function( sourceStream, endStream ){
-  endStream = endStream || dbclient();
+  endStream = endStream || dbclient({name: 'geonames'});
 
   return sourceStream.pipe( geonames.pipeline )
     .pipe( featureCodeFilterStream.create() )

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "mkdirp": "^0.5.1",
     "pelias-blacklist-stream": "^1.0.0",
     "pelias-config": "^3.3.0",
-    "pelias-dbclient": "^2.5.6",
+    "pelias-dbclient": "^2.8.0",
     "pelias-logger": "^1.2.1",
     "pelias-model": "^5.7.1",
     "pelias-wof-admin-lookup": "^5.0.0",


### PR DESCRIPTION
This allows distinguishing which logger output lines correspond to which
importer during an import.

Connects https://github.com/pelias/dbclient/issues/101