### PR TITLE
bump NodeJS memory requirements to 6 GB

### DIFF
--- a/bin/start
+++ b/bin/start
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-exec node --max_old_space_size=4096 import.js
+exec node --max_old_space_size=6000 import.js


### PR DESCRIPTION
WOF data recently exceeded the 4 GB memory limit for admin-lookup