### PR TITLE
tests(streams) change event-stream to stream-mock

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   },
   "devDependencies": {
     "deep-diff": "^1.0.0",
-    "event-stream": "^4.0.0",
+    "stream-mock": "^2.0.3",
     "pelias-mock-logger": "^1.1.0",
     "precommit-hook": "^3.0.0",
     "proxyquire": "^2.0.0",

--- a/test/streams/layerMappingStreamTest.js
+++ b/test/streams/layerMappingStreamTest.js
@@ -1,14 +1,16 @@
 var tape = require('tape');
-var event_stream = require('event-stream');
 
 var layerMappingStream = require('../../lib/streams/layerMappingStream');
 var featureCodeToLayer = layerMappingStream.featureCodeToLayer;
 
-function test_stream(input, testedStream, callback) {
-    var input_stream = event_stream.readArray(input);
-    var destination_stream = event_stream.writeArray(callback);
+const stream_mock = require('stream-mock');
 
-    input_stream.pipe(testedStream).pipe(destination_stream);
+function test_stream(input, testedStream, callback) {
+  const reader = new stream_mock.ObjectReadableMock(input);
+  const writer = new stream_mock.ObjectWritableMock();
+  writer.on('error', (e) => callback(e));
+  writer.on('finish', () => callback(null, writer.data));
+  reader.pipe(testedStream).pipe(writer);
 }
 
 tape('featureCodeToLayer', function(test) {

--- a/test/streams/overrideLookedUpLocalityAndLocaladmin.js
+++ b/test/streams/overrideLookedUpLocalityAndLocaladmin.js
@@ -1,15 +1,18 @@
 var tape = require('tape');
-var event_stream = require('event-stream');
 var Document = require('pelias-model').Document;
 
 var overrideLookedUpLocalityAndLocaladmin = require('../../lib/streams/overrideLookedUpLocalityAndLocaladmin');
 
-function test_stream(input, testedStream, callback) {
-    var input_stream = event_stream.readArray(input);
-    var destination_stream = event_stream.writeArray(callback);
+const stream_mock = require('stream-mock');
 
-    input_stream.pipe(testedStream).pipe(destination_stream);
+function test_stream(input, testedStream, callback) {
+  const reader = new stream_mock.ObjectReadableMock(input);
+  const writer = new stream_mock.ObjectWritableMock();
+  writer.on('error', (e) => callback(e));
+  writer.on('finish', () => callback(null, writer.data));
+  reader.pipe(testedStream).pipe(writer);
 }
+
 
 tape('peliasDocGenerator', function(test) {
   test.test('document with layer=locality should overwrite locality parent with name and id', function(t) {

--- a/test/streams/peliasDocGeneratorTest.js
+++ b/test/streams/peliasDocGeneratorTest.js
@@ -1,15 +1,17 @@
 var tape = require('tape');
 var Document = require('pelias-model').Document;
 var peliasDocGenerator = require('../../lib/streams/peliasDocGenerator');
-var event_stream = require('event-stream');
 const proxyquire = require('proxyquire').noCallThru();
+const stream_mock = require('stream-mock');
 
 function test_stream(input, testedStream, callback) {
-    var input_stream = event_stream.readArray(input);
-    var destination_stream = event_stream.writeArray(callback);
-
-    input_stream.pipe(testedStream).pipe(destination_stream);
+  const reader = new stream_mock.ObjectReadableMock(input);
+  const writer = new stream_mock.ObjectWritableMock();
+  writer.on('error', (e) => callback(e));
+  writer.on('finish', () => callback(null, writer.data));
+  reader.pipe(testedStream).pipe(writer);
 }
+
 
 tape('peliasDocGenerator', function(test) {
   test.test('basic data should should be returned as Document objects with only ' +


### PR DESCRIPTION
Replacing event-stream with stream-mock as discussed in pelias/pelias#801

_Can you double check `importTest.js`? I am not sure the test is correct to begin with_
Edit: found the proble, just had to run functional tests