### PR TITLE
feat(name): Add stream for adjusting the name

### DIFF
--- a/lib/adjustName.js
+++ b/lib/adjustName.js
@@ -1,0 +1,11 @@
+module.exports = function adjustName(doc){
+  const default_name = doc.getName('default');
+
+  const starts_with_city_of = /^City of /;
+  if (starts_with_city_of.test(default_name)) {
+    doc.setName('default', default_name.replace(/^City of /, ''));
+    doc.setNameAlias('default', default_name);
+  }
+
+  return doc;
+};

--- a/lib/streams/adjustName.js
+++ b/lib/streams/adjustName.js
@@ -1,0 +1,9 @@
+const through = require('through2');
+
+const adjustName = require('../adjustName');
+
+module.exports = function create() {
+  return through.obj(function(doc, enc, next) {
+    next(null, adjustName(doc));
+  });
+};

--- a/lib/tasks/import.js
+++ b/lib/tasks/import.js
@@ -8,6 +8,7 @@ var adminLookupStream = require('pelias-wof-admin-lookup');
 var layerMappingStream = require('../streams/layerMappingStream');
 var peliasDocGenerator = require('../streams/peliasDocGenerator');
 var overrideLookedUpLocalityAndLocaladmin = require('../streams/overrideLookedUpLocalityAndLocaladmin');
+const adjustNameStream = require('../streams/adjustName');
 
 module.exports = function( sourceStream, endStream ){
   endStream = endStream || dbclient({name: 'geonames'});
@@ -18,6 +19,7 @@ module.exports = function( sourceStream, endStream ){
     .pipe( peliasDocGenerator.create() )
     .pipe( blacklistStream() )
     .pipe( adminLookupStream.create() )
+    .pipe( adjustNameStream() )
     .pipe( overrideLookedUpLocalityAndLocaladmin.create() )
     .pipe(model.createDocumentMapperStream())
     .pipe( endStream );

--- a/test/lib/adjustName.js
+++ b/test/lib/adjustName.js
@@ -1,0 +1,38 @@
+const tape = require('tape');
+const adjustName = require('../../lib/adjustName');
+const Document = require('pelias-model').Document;
+
+tape('adjustName', function(test) {
+  test.test('standard record should be unchanged', function (t) {
+    const input_doc = new Document('geonames', 'locality', 1234567)
+      .setName('default', 'Normal name');
+
+    const output = adjustName(input_doc);
+
+    t.equal(output.name.default, 'Normal name', 'name unchanged');
+    t.end();
+  });
+
+  test.test('name starting with City of should be moved to alias', function (t) {
+    const input_doc = new Document('geonames', 'locality', 1234567)
+      .setName('default', 'City of Detroit');
+
+    const output = adjustName(input_doc);
+
+    t.deepEquals(output.name.default, ['Detroit', 'City of Detroit'], 'name alias created');
+    t.end();
+  });
+
+  test.test('existing aliases should be respected', function (t) {
+    const input_doc = new Document('geonames', 'locality', 1234567)
+      .setName('default', 'City of Detroit')
+      .setNameAlias('default', 'Hockeytown');
+
+    const output = adjustName(input_doc);
+
+    const expected = ['Detroit', 'Hockeytown', 'City of Detroit'];
+    t.deepEquals(output.name.default, expected, 'name alias created, existing alias kept');
+    t.end();
+  });
+
+});

--- a/test/units.js
+++ b/test/units.js
@@ -2,3 +2,4 @@ require ('./streams/peliasDocGeneratorTest.js');
 require ('./streams/layerMappingStreamTest.js');
 require ('./streams/featureCodeFilterStream');
 require ('./streams/overrideLookedUpLocalityAndLocaladmin');
+require ('./lib/adjustName');


### PR DESCRIPTION
To start, this includes a function that takes any record with the name 'City of X' and ensures the primary default name is 'X', with 'City of X' moved to an alias.

This pattern is quite common in Geonames data and makes it much harder to correctly deduplicate in the API.
