### PR TITLE
chore(tests): Update test expectations for new doc type name

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "lodash": "^4.17.15",
     "mkdirp": "^0.5.1",
     "pelias-blacklist-stream": "^1.2.0",
-    "pelias-config": "^4.5.0",
+    "pelias-config": "^4.8.0",
     "pelias-dbclient": "^2.13.0",
     "pelias-logger": "^1.4.1",
     "pelias-model": "^7.1.0",

--- a/test/data/expected.json
+++ b/test/data/expected.json
@@ -2,7 +2,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880131",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Pagar"
@@ -37,7 +37,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880133",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Yuchi"
@@ -61,7 +61,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880134",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Yio Chu Kang Estate"
@@ -95,7 +95,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880135",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Yio Chu Kang"
@@ -130,7 +130,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880136",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Yio Chu Kang I"
@@ -150,7 +150,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880137",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Yew Tee"
@@ -185,7 +185,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880138",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Yan Kit"
@@ -208,7 +208,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880139",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Woollerton Park"
@@ -231,7 +231,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880140",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Woodleigh Park"
@@ -254,7 +254,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880141",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Windsor Park Estate"
@@ -277,7 +277,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880142",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Whampoa"
@@ -301,7 +301,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880143",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "West Reach"
@@ -325,7 +325,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880144",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "West Coast Village"
@@ -360,7 +360,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880145",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "West Bukit Timah"
@@ -383,7 +383,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880146",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Wessex Estate"
@@ -406,7 +406,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880147",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bukit Wayang Satu"
@@ -429,7 +429,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880148",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Watten Park"
@@ -452,7 +452,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880149",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Wan Chi"
@@ -476,7 +476,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880150",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Wak Logok"
@@ -500,7 +500,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880151",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Wak Bachok"
@@ -524,7 +524,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880152",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Wak Abu"
@@ -548,7 +548,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880153",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Victoria Park"
@@ -571,7 +571,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880154",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Mount Victoria"
@@ -594,7 +594,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880155",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Mount Vernon"
@@ -617,7 +617,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880156",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Unum"
@@ -641,7 +641,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880157",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Unum"
@@ -664,7 +664,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880158",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Ulu Pandan"
@@ -688,7 +688,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880159",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Ulu Bedok"
@@ -723,7 +723,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880160",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Ulu Bedok"
@@ -743,7 +743,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880161",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Ular"
@@ -766,7 +766,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880162",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Ubin"
@@ -789,7 +789,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880163",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tyersall Park"
@@ -812,7 +812,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880164",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Tumbok Opih"
@@ -836,7 +836,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880165",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Terumbu Tukak"
@@ -860,7 +860,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880166",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Tuas"
@@ -883,7 +883,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880167",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Tuas"
@@ -907,7 +907,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880168",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tuas"
@@ -930,7 +930,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880169",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tua Kang Lye"
@@ -953,7 +953,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880170",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Trus Pandan"
@@ -977,7 +977,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880171",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Trus"
@@ -1001,7 +1001,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880172",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Town Reach"
@@ -1025,7 +1025,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880173",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Tongkang"
@@ -1049,7 +1049,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880174",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Tok"
@@ -1072,7 +1072,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880175",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Todak"
@@ -1095,7 +1095,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880176",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Toa Payoh New Town"
@@ -1118,7 +1118,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880177",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tiong Bahru Estate"
@@ -1141,7 +1141,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880178",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bukit Tinggi"
@@ -1164,7 +1164,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880179",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bukit Timah"
@@ -1187,7 +1187,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880180",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Tiga"
@@ -1211,7 +1211,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880181",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Malang Tiga"
@@ -1234,7 +1234,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880182",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Tho Pek Kong"
@@ -1258,7 +1258,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880183",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Thong Hoe Village"
@@ -1293,7 +1293,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880184",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Thomson"
@@ -1316,7 +1316,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880185",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Teritip"
@@ -1339,7 +1339,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880186",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Teris"
@@ -1363,7 +1363,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880187",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Terih"
@@ -1386,7 +1386,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880188",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Terembu Gayong"
@@ -1409,7 +1409,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880189",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Tereh"
@@ -1432,7 +1432,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880190",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Teregeh"
@@ -1455,7 +1455,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880191",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Tengeh"
@@ -1478,7 +1478,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880192",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Tengeh"
@@ -1502,7 +1502,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880193",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Tengah"
@@ -1526,7 +1526,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880194",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Tengah"
@@ -1550,7 +1550,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880195",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tengah Air Base"
@@ -1575,7 +1575,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880196",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Tembuan"
@@ -1599,7 +1599,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880197",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Tembakul"
@@ -1622,7 +1622,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880198",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tembaga Reef"
@@ -1646,7 +1646,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880199",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Telok Ayer Basin"
@@ -1672,7 +1672,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880200",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Telok"
@@ -1696,7 +1696,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880201",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kuala Telok"
@@ -1720,7 +1720,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880202",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Tekukor"
@@ -1743,7 +1743,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880203",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Tekong Kechil"
@@ -1766,7 +1766,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880204",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Tekong"
@@ -1789,7 +1789,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880205",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Teck Hock"
@@ -1812,7 +1812,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880206",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Teck Chong Estate"
@@ -1846,7 +1846,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880208",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tay Keng Loon Estate"
@@ -1880,7 +1880,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880209",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Tanjong Gul"
@@ -1904,7 +1904,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880210",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Tanjong"
@@ -1928,7 +1928,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880211",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tan Hua Gek Estate"
@@ -1962,7 +1962,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880212",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanglin Railway Station"
@@ -1986,7 +1986,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880213",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanglin Hill"
@@ -2009,7 +2009,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880214",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanglin"
@@ -2032,7 +2032,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880215",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Tanah Merah Besar"
@@ -2056,7 +2056,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880216",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tampines Estate"
@@ -2079,7 +2079,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880217",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Tampines"
@@ -2103,7 +2103,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880218",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Tajam"
@@ -2126,7 +2126,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880219",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tai Seng"
@@ -2149,7 +2149,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880220",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tai San Estate"
@@ -2173,7 +2173,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880221",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Taib"
@@ -2197,7 +2197,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880222",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Swiss Cottage Estate"
@@ -2221,7 +2221,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880223",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Surat"
@@ -2244,7 +2244,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880224",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Unum Estate"
@@ -2278,7 +2278,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880225",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Tampines"
@@ -2298,7 +2298,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880226",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Simpang"
@@ -2333,7 +2333,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880227",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Pus"
@@ -2353,7 +2353,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880228",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Buloh Estate"
@@ -2377,7 +2377,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880229",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sultan Shoal"
@@ -2401,7 +2401,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880230",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Selat Sudong"
@@ -2425,7 +2425,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880231",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Sudong"
@@ -2448,7 +2448,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880232",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Subar Laut"
@@ -2471,7 +2471,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880233",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Subar Darat"
@@ -2494,7 +2494,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880234",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Stamford Canal"
@@ -2518,7 +2518,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880235",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Squance Bank"
@@ -2541,7 +2541,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880236",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Spring Park Estate"
@@ -2564,7 +2564,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880237",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Spau"
@@ -2587,7 +2587,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880238",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "South Channel"
@@ -2611,7 +2611,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880239",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Sopok"
@@ -2635,7 +2635,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880240",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Mount Sophia"
@@ -2658,7 +2658,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880241",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Song Hah Estate"
@@ -2692,7 +2692,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880242",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Somapah Serangoon"
@@ -2727,7 +2727,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880243",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Somapah Changi"
@@ -2750,7 +2750,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880244",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Skopek"
@@ -2773,7 +2773,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880245",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sin Watt Estate"
@@ -2807,7 +2807,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880246",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Selat Sinki"
@@ -2831,7 +2831,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880247",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Singapore United Plantation"
@@ -2865,7 +2865,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880248",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Singapore River"
@@ -2889,7 +2889,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880249",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Singapore Island"
@@ -2912,7 +2912,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880250",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Paya Lebar Airport"
@@ -2937,7 +2937,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:country:1880251",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Republic of Singapore"
@@ -2961,7 +2961,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880252",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Singapore"
@@ -2998,7 +2998,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880253",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Simpang Mak Wai"
@@ -3022,7 +3022,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880254",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Simpang Kiri"
@@ -3046,7 +3046,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880255",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Simpang Kanan"
@@ -3070,7 +3070,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880256",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Simpang Bedok Village"
@@ -3093,7 +3093,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880257",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Simpang"
@@ -3117,7 +3117,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880258",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Simpang"
@@ -3140,7 +3140,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880259",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Mount Siloso"
@@ -3163,7 +3163,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880260",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Siglap"
@@ -3197,7 +3197,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880261",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Karang Si Ajar"
@@ -3220,7 +3220,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880262",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Telok Serong"
@@ -3244,7 +3244,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880263",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Seringat"
@@ -3267,7 +3267,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880264",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Seraya"
@@ -3290,7 +3290,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880265",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Mount Serapong"
@@ -3313,7 +3313,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880266",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Serangoon Kechil"
@@ -3337,7 +3337,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880267",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Serangoon Harbour"
@@ -3363,7 +3363,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880268",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Serangoon Garden Estate"
@@ -3386,7 +3386,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880269",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Serangoon"
@@ -3410,7 +3410,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880270",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Serangoon"
@@ -3433,7 +3433,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880271",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Serangoon"
@@ -3456,7 +3456,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880272",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sentosa Island"
@@ -3479,7 +3479,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880273",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Senoko"
@@ -3503,7 +3503,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880274",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sennett Estate"
@@ -3526,7 +3526,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880275",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Selat Sengkir"
@@ -3550,7 +3550,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880276",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Senang"
@@ -3573,7 +3573,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880277",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Semechek"
@@ -3596,7 +3596,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880278",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Sembilang"
@@ -3620,7 +3620,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880279",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Sembilang"
@@ -3644,7 +3644,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880280",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Sembawang Kechil"
@@ -3668,7 +3668,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880281",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sembawang Hills Estate"
@@ -3691,7 +3691,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880282",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Sembawang"
@@ -3715,7 +3715,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880283",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sembawang Estate"
@@ -3749,7 +3749,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880284",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Semakau"
@@ -3772,7 +3772,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880285",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Selolo"
@@ -3796,7 +3796,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880286",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Terumbu Selit"
@@ -3820,7 +3820,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880287",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Seletar Simpang Kiri"
@@ -3844,7 +3844,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880288",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Seletar Simpang Kanan"
@@ -3868,7 +3868,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880289",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Seletar Reservoir"
@@ -3892,7 +3892,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880290",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Seletar North"
@@ -3912,7 +3912,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880291",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Seletar Hills Estate"
@@ -3946,7 +3946,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880292",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Seletar"
@@ -3970,7 +3970,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880293",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Seletar"
@@ -3993,7 +3993,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880294",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Seletar"
@@ -4028,7 +4028,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880295",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Seletar Airport"
@@ -4053,7 +4053,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880296",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Selegu"
@@ -4076,7 +4076,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880297",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Selarang"
@@ -4100,7 +4100,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880298",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Sekudu"
@@ -4123,7 +4123,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880299",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Segar"
@@ -4147,7 +4147,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880300",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Seburus Luar"
@@ -4170,7 +4170,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880301",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Seburus Dalam"
@@ -4193,7 +4193,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880302",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Sebarok"
@@ -4216,7 +4216,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880303",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sea View Estate"
@@ -4239,7 +4239,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880304",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Sawa"
@@ -4263,7 +4263,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880305",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Satumu"
@@ -4286,7 +4286,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880306",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sarimbun Rocks"
@@ -4309,7 +4309,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880307",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Sarimbun"
@@ -4333,7 +4333,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880308",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Sarimbun"
@@ -4356,7 +4356,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880309",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sarang Rimau"
@@ -4391,7 +4391,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880310",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Sanyongkong"
@@ -4415,7 +4415,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880311",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Sanyongkong"
@@ -4438,7 +4438,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880312",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Selat Samulun"
@@ -4462,7 +4462,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880313",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Samulun"
@@ -4485,7 +4485,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880314",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sam Heng Estate"
@@ -4519,7 +4519,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880315",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Selat Salu"
@@ -4543,7 +4543,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880316",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Salu"
@@ -4566,7 +4566,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880317",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Salohor"
@@ -4590,7 +4590,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880318",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bukit Saleh"
@@ -4613,7 +4613,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880319",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Sakunyit"
@@ -4636,7 +4636,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880320",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Selat Sakra"
@@ -4660,7 +4660,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880321",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Sakra"
@@ -4683,7 +4683,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880322",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Sakijang Pelepah"
@@ -4706,7 +4706,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880323",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Sakijang Bendera"
@@ -4729,7 +4729,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880324",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Sakeng"
@@ -4752,7 +4752,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880325",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Sajahat Kechil"
@@ -4775,7 +4775,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880326",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Sajahat"
@@ -4798,7 +4798,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880327",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Saint John Islands"
@@ -4821,7 +4821,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880328",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sagenting"
@@ -4845,7 +4845,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880329",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Saga"
@@ -4880,7 +4880,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880330",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Mount Rosie"
@@ -4903,7 +4903,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880331",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Romos"
@@ -4926,7 +4926,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880332",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Rochor River"
@@ -4950,7 +4950,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880333",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Rochor Canal"
@@ -4974,7 +4974,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880334",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Rochester Park"
@@ -4997,7 +4997,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880335",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Rhu"
@@ -5020,7 +5020,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880336",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Renggis"
@@ -5043,7 +5043,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880337",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Renggam"
@@ -5066,7 +5066,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880338",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Red Cliff Bank"
@@ -5089,7 +5089,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880339",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Read Rock"
@@ -5112,7 +5112,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880340",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Ranggong"
@@ -5136,7 +5136,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880341",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Rajah Prang Channel"
@@ -5160,7 +5160,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880342",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Raffles Park"
@@ -5183,7 +5183,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880343",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Race Course Village"
@@ -5206,7 +5206,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880344",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Queen Astrid Park"
@@ -5229,7 +5229,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880345",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Putri Narrows"
@@ -5253,7 +5253,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880346",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Batu Puteh"
@@ -5276,7 +5276,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880347",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Punggol"
@@ -5300,7 +5300,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880348",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Punggol"
@@ -5335,7 +5335,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880349",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Ubin Estate"
@@ -5369,7 +5369,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880350",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Pulau Ubin"
@@ -5393,7 +5393,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880351",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Ubin Village"
@@ -5428,7 +5428,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880352",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Pulau Seraya"
@@ -5452,7 +5452,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880353",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Minyak"
@@ -5475,7 +5475,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880354",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Selat Damar Laut"
@@ -5499,7 +5499,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880355",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bukit Timah Nature Reserve"
@@ -5522,7 +5522,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880356",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Puak Besar"
@@ -5546,7 +5546,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880357",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Puaka"
@@ -5570,7 +5570,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880358",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Puaka"
@@ -5594,7 +5594,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880359",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Puaka"
@@ -5614,7 +5614,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880360",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Princess Elizabeth Estate"
@@ -5637,7 +5637,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880361",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Prince Edward Point"
@@ -5660,7 +5660,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880362",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Prince Edward Park"
@@ -5683,7 +5683,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880363",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Prawn Pond Reserve"
@@ -5706,7 +5706,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880364",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Poyan"
@@ -5730,7 +5730,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880365",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Poh Thian Hock Soon Hin Estate"
@@ -5754,7 +5754,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880366",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Mount Pleasant"
@@ -5777,7 +5777,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880367",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Playfair Estate"
@@ -5800,7 +5800,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880368",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Pinang"
@@ -5824,7 +5824,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880369",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Pinang"
@@ -5848,7 +5848,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880370",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Pidara"
@@ -5871,7 +5871,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880371",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Piatu"
@@ -5895,7 +5895,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880372",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bukit Piatu"
@@ -5918,7 +5918,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880373",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Phoenix Park"
@@ -5941,7 +5941,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880374",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Phillip Channel"
@@ -5965,7 +5965,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880375",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Petemin"
@@ -5988,7 +5988,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880376",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Petai"
@@ -6012,7 +6012,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880377",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Pesek"
@@ -6036,7 +6036,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880378",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Selat Pesek"
@@ -6060,7 +6060,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880379",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Pesek"
@@ -6083,7 +6083,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880380",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Terumbu Pesak"
@@ -6107,7 +6107,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880381",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Perseverance Estate"
@@ -6130,7 +6130,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880382",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Perpat Mati"
@@ -6153,7 +6153,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880383",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Pergam"
@@ -6177,7 +6177,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880384",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Pergam"
@@ -6200,7 +6200,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880385",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Perepat Tinggi"
@@ -6223,7 +6223,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880386",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Perepat"
@@ -6247,7 +6247,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880387",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Perempan Besar"
@@ -6271,7 +6271,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880388",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Penyalai"
@@ -6294,7 +6294,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880389",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Penjuru"
@@ -6317,7 +6317,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880390",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Peng Siang"
@@ -6341,7 +6341,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880391",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Peng Kang"
@@ -6361,7 +6361,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880392",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Parit Pengkalan Pakau"
@@ -6385,7 +6385,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880393",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Palawan"
@@ -6409,7 +6409,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880394",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Lower Peirce Reservoir"
@@ -6433,7 +6433,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880395",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pearls Hill"
@@ -6456,7 +6456,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880396",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Paya Lebar South"
@@ -6479,7 +6479,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880397",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Paya Lebar North"
@@ -6502,7 +6502,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880398",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Paya Lebar"
@@ -6525,7 +6525,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880399",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Terembu Paya"
@@ -6549,7 +6549,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880400",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Pawai"
@@ -6572,7 +6572,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880401",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pasir Panjang"
@@ -6595,7 +6595,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880402",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pasir Panjang Park"
@@ -6618,7 +6618,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880403",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Pasir Laba"
@@ -6641,7 +6641,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880404",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Pasir Laba"
@@ -6665,7 +6665,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880405",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Pasir"
@@ -6688,7 +6688,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880406",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Pasir"
@@ -6712,7 +6712,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880407",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Pasir"
@@ -6736,7 +6736,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880408",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Pasir"
@@ -6760,7 +6760,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880409",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Pasir"
@@ -6784,7 +6784,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880410",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Pasir"
@@ -6808,7 +6808,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880411",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Malang Papan"
@@ -6831,7 +6831,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880412",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bukit Panjang"
@@ -6854,7 +6854,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880413",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Pang Sua"
@@ -6878,7 +6878,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880414",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Pangkong"
@@ -6901,7 +6901,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880415",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pandan Nature Reserve"
@@ -6924,7 +6924,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880416",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Pandan Kechil"
@@ -6948,7 +6948,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880417",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bukit Pandan Kechil"
@@ -6971,7 +6971,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880418",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Pandan"
@@ -6995,7 +6995,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880419",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Selat Pandan"
@@ -7019,7 +7019,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880420",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pandan IV"
@@ -7039,7 +7039,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880421",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Pagar"
@@ -7062,7 +7062,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880422",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Outer Shoal"
@@ -7085,7 +7085,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880423",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Outer Roads"
@@ -7111,7 +7111,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880424",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Ordnance Reach"
@@ -7135,7 +7135,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880425",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Terumbu Opih"
@@ -7159,7 +7159,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880426",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Opera Estate"
@@ -7182,7 +7182,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880427",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Ong Ting Lye Estate"
@@ -7216,7 +7216,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880428",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Ong Lee"
@@ -7251,7 +7251,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880429",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Ong Boon and Khoo Soo Chays Estate"
@@ -7275,7 +7275,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880430",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Old Kallang Airport Estate"
@@ -7298,7 +7298,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880431",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Oei Tiong Ham Park"
@@ -7321,7 +7321,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880432",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Nipah"
@@ -7345,7 +7345,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880433",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Nipah"
@@ -7369,7 +7369,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880434",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Ng Kay Boon Estate"
@@ -7403,7 +7403,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880435",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Nepal Park"
@@ -7426,7 +7426,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880436",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Keramat Nenak"
@@ -7449,7 +7449,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880437",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Nee Soon Estate"
@@ -7484,7 +7484,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880438",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "The Narrows"
@@ -7508,7 +7508,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880439",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Nanyang University"
@@ -7531,7 +7531,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880440",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Nangka"
@@ -7555,7 +7555,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880441",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Nenas Channel"
@@ -7579,7 +7579,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880442",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Namly"
@@ -7603,7 +7603,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880443",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Namazie Estate"
@@ -7637,7 +7637,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880444",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Murnane Reservoir"
@@ -7661,7 +7661,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880445",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Murai"
@@ -7684,7 +7684,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880446",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Murai"
@@ -7708,7 +7708,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880447",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Muka Dua"
@@ -7732,7 +7732,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880448",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Mok Peng Hiang Estate"
@@ -7766,7 +7766,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880449",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Middle Channel"
@@ -7790,7 +7790,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880450",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Terumbu Meskol"
@@ -7814,7 +7814,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880451",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Meskol"
@@ -7837,7 +7837,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880452",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Mesemut Laut"
@@ -7860,7 +7860,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880453",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Mesemut Darat"
@@ -7883,7 +7883,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880454",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Merlimau"
@@ -7907,7 +7907,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880455",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Merlimau"
@@ -7930,7 +7930,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880456",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Merawang"
@@ -7953,7 +7953,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880457",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Merawang"
@@ -7977,7 +7977,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880458",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Merawang"
@@ -8000,7 +8000,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880459",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Mengkwang"
@@ -8023,7 +8023,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880460",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Melayu"
@@ -8047,7 +8047,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880461",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Medway Park"
@@ -8070,7 +8070,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880462",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "McMahon Park"
@@ -8093,7 +8093,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880463",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Matilda Estate"
@@ -8127,7 +8127,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880464",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Mata Ikan"
@@ -8151,7 +8151,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880465",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Mata Ikan"
@@ -8174,7 +8174,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880466",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Mat"
@@ -8197,7 +8197,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880467",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Maryland Estate"
@@ -8220,7 +8220,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880468",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Marsiling Estate"
@@ -8254,7 +8254,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880469",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Marsiling"
@@ -8289,7 +8289,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880470",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Man-of-War Anchorage"
@@ -8315,7 +8315,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880471",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Mandai Kechil"
@@ -8339,7 +8339,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880472",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Mandai"
@@ -8363,7 +8363,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880473",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bukit Mandai II"
@@ -8383,7 +8383,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880474",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Mamam"
@@ -8407,7 +8407,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880476",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Batu Malang Beldaun"
@@ -8430,7 +8430,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880478",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Mak Baok"
@@ -8453,7 +8453,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880479",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Mak Aerik"
@@ -8476,7 +8476,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880481",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "MacRitchie Reservoir"
@@ -8500,7 +8500,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880482",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Lumpur"
@@ -8524,7 +8524,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880483",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Lucy Rocks"
@@ -8547,7 +8547,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880484",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Loyang"
@@ -8571,7 +8571,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880485",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Lorong Tiga Estate"
@@ -8594,7 +8594,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880486",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Lokyang"
@@ -8617,7 +8617,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880487",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Lokos"
@@ -8640,7 +8640,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880488",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Linggang"
@@ -8664,7 +8664,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880489",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Lim Chu Kang Estate"
@@ -8698,7 +8698,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880490",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Leedon Park"
@@ -8721,7 +8721,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880491",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Lavis Shoal"
@@ -8744,7 +8744,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880492",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Latoh"
@@ -8768,7 +8768,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880493",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Lam San Village"
@@ -8803,7 +8803,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880494",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Lam Kiong Estate"
@@ -8826,7 +8826,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880495",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Lam Hong Estate"
@@ -8860,7 +8860,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880496",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Ladang"
@@ -8883,7 +8883,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880497",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Labu"
@@ -8907,7 +8907,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880498",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Laboh Gandom"
@@ -8931,7 +8931,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880499",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Beting Kusah"
@@ -8954,7 +8954,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880500",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Kubang Babi"
@@ -8978,7 +8978,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880501",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kubang Babi"
@@ -9001,7 +9001,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880502",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kuala Berih Estate"
@@ -9025,7 +9025,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880503",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Kranji"
@@ -9049,7 +9049,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880504",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Kling"
@@ -9072,7 +9072,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880505",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kingsmead Hall"
@@ -9095,7 +9095,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880506",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "King Albert Park"
@@ -9118,7 +9118,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880507",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kilburn Estate"
@@ -9141,7 +9141,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880508",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kian Teck San Estate"
@@ -9164,7 +9164,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880509",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kian Hong Estate"
@@ -9187,7 +9187,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880510",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Khatib Bongsu"
@@ -9211,7 +9211,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880511",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Ketapang"
@@ -9235,7 +9235,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880512",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Ketam Channel"
@@ -9259,7 +9259,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880513",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Ketam"
@@ -9282,7 +9282,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880514",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Keppel Harbour"
@@ -9308,7 +9308,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880515",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kent Ridge"
@@ -9331,7 +9331,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880516",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Kedut"
@@ -9355,7 +9355,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880517",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Keat Hong Village"
@@ -9390,7 +9390,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880518",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Katong"
@@ -9413,7 +9413,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880519",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Selat Karang Kait"
@@ -9437,7 +9437,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880520",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Karang"
@@ -9460,7 +9460,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880521",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Karang"
@@ -9484,7 +9484,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880522",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Kangkar"
@@ -9508,7 +9508,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880523",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Woodleigh"
@@ -9531,7 +9531,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880524",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Wak Tanjong"
@@ -9554,7 +9554,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880525",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Wak Sekak"
@@ -9589,7 +9589,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880526",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Wak Hassan"
@@ -9624,7 +9624,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880527",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Wak Dulah"
@@ -9659,7 +9659,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880528",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Wak Bechik"
@@ -9694,7 +9694,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880529",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Unum"
@@ -9729,7 +9729,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880530",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Ulu Pandan"
@@ -9752,7 +9752,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880531",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Ulu Jurong"
@@ -9787,7 +9787,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880532",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Ubi"
@@ -9822,7 +9822,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880533",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Tulloch"
@@ -9845,7 +9845,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880534",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Tongkang Pechah"
@@ -9880,7 +9880,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880535",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Todak"
@@ -9915,7 +9915,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880536",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tengah"
@@ -9950,7 +9950,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880537",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Telok"
@@ -9985,7 +9985,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880538",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Tebing Terjun"
@@ -10020,7 +10020,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880539",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Teban"
@@ -10055,7 +10055,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880540",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Tanjong Penjuru"
@@ -10090,7 +10090,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880541",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Tanjong Irau"
@@ -10125,7 +10125,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880542",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Tanah Merah"
@@ -10148,7 +10148,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880543",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Tampines"
@@ -10171,7 +10171,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880544",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Sungai Tengah"
@@ -10206,7 +10206,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880545",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Sungai Pandan"
@@ -10241,7 +10241,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880546",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Sungai Jurong"
@@ -10276,7 +10276,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880547",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Sungai Blukar"
@@ -10311,7 +10311,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880548",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Sungai Belang"
@@ -10346,7 +10346,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880549",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Sultan"
@@ -10369,7 +10369,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880550",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Sudong"
@@ -10404,7 +10404,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880551",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Soopoo"
@@ -10427,7 +10427,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880552",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Sireh"
@@ -10462,7 +10462,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880553",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Seraya"
@@ -10497,7 +10497,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880554",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Serangoon Kechil"
@@ -10532,7 +10532,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880555",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Seminei"
@@ -10567,7 +10567,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880556",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Sanyonkong Parit"
@@ -10602,7 +10602,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880557",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Sanyongkong"
@@ -10637,7 +10637,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880558",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong San Teng"
@@ -10660,7 +10660,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880559",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Salabin"
@@ -10695,7 +10695,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880560",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Saigon"
@@ -10730,7 +10730,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880561",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Reteh"
@@ -10765,7 +10765,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880562",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Radin Mas"
@@ -10788,7 +10788,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880563",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Punggol"
@@ -10823,7 +10823,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880564",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Kampong Pulau Seraya"
@@ -10847,7 +10847,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880565",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Pulau Kechil"
@@ -10882,7 +10882,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880566",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Potong Pasir"
@@ -10905,7 +10905,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880567",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Pinang"
@@ -10940,7 +10940,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880568",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Pesek"
@@ -10975,7 +10975,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880569",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Permatang"
@@ -11010,7 +11010,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880570",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Perigi Piau"
@@ -11045,7 +11045,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880571",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Pengkalan Petai"
@@ -11080,7 +11080,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880572",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Pengkalan Pakau"
@@ -11115,7 +11115,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880573",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Pengkalan Kundor"
@@ -11150,7 +11150,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880574",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Pasir Ris"
@@ -11185,7 +11185,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880575",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Pasir Merah"
@@ -11220,7 +11220,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880576",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Pasir"
@@ -11255,7 +11255,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880577",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Pahang"
@@ -11290,7 +11290,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880578",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Padang Terbakar"
@@ -11313,7 +11313,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880579",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Pachitan"
@@ -11348,7 +11348,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880580",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong O’Carroll Scott"
@@ -11371,7 +11371,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880581",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Noordin"
@@ -11406,7 +11406,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880582",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Melayu"
@@ -11441,7 +11441,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880583",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Mandai Kechil"
@@ -11476,7 +11476,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880584",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Mamam"
@@ -11511,7 +11511,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880585",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Mak Baok"
@@ -11546,7 +11546,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880586",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Loyang"
@@ -11581,7 +11581,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880587",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Lew Lian"
@@ -11616,7 +11616,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880588",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Ladang"
@@ -11651,7 +11651,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880589",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Ladang"
@@ -11686,7 +11686,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880590",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Kuchai"
@@ -11709,7 +11709,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880591",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Kranji"
@@ -11744,7 +11744,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880592",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Kopit"
@@ -11779,7 +11779,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880593",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Kitin"
@@ -11814,7 +11814,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880594",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kembangan"
@@ -11837,7 +11837,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880595",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Kebun Baharu"
@@ -11872,7 +11872,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880596",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Jelutong"
@@ -11907,7 +11907,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880597",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Java Teban"
@@ -11942,7 +11942,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880598",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Jagoh"
@@ -11965,7 +11965,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880599",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Hock Soon"
@@ -11988,7 +11988,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880600",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Eunos"
@@ -12011,7 +12011,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880601",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Cutforth"
@@ -12046,7 +12046,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880602",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Che Jevah"
@@ -12081,7 +12081,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880603",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Chantek Baharu"
@@ -12104,7 +12104,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880604",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Changi"
@@ -12139,7 +12139,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880605",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Chai Chee"
@@ -12174,7 +12174,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880606",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Bukit Panjang"
@@ -12209,7 +12209,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880607",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Bugis"
@@ -12232,7 +12232,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880608",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Bugis"
@@ -12255,7 +12255,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880609",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Bugis"
@@ -12290,7 +12290,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880610",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Blukang"
@@ -12325,7 +12325,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880611",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Beremban"
@@ -12360,7 +12360,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880612",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Bereh"
@@ -12383,7 +12383,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880613",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Belimbing"
@@ -12417,7 +12417,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880614",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Batu Koyok"
@@ -12452,7 +12452,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880616",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Bahru"
@@ -12487,7 +12487,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880617",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Baharu"
@@ -12522,7 +12522,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880618",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Ayer Samak Darat"
@@ -12557,7 +12557,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880619",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Ayer Samak"
@@ -12592,7 +12592,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880620",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Ayer Merbau"
@@ -12627,7 +12627,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880621",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Ayer Limau"
@@ -12662,7 +12662,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880622",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Ayer Gemuruh"
@@ -12697,7 +12697,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880623",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Ayer Bajau"
@@ -12732,7 +12732,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880624",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Amoy Quee"
@@ -12767,7 +12767,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880625",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Amber"
@@ -12790,7 +12790,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880626",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kallang River"
@@ -12814,7 +12814,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880627",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bukit Kalang"
@@ -12837,7 +12837,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880628",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kalang"
@@ -12860,7 +12860,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880629",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Kadut"
@@ -12884,7 +12884,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880630",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Jurong"
@@ -12908,7 +12908,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880631",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Selat Jurong"
@@ -12932,7 +12932,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880632",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Joo Lim Estate"
@@ -12956,7 +12956,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880633",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Jong"
@@ -12979,7 +12979,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880634",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Jones Reef"
@@ -13002,7 +13002,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880635",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Johore Shoal"
@@ -13025,7 +13025,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880636",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Jelutong"
@@ -13048,7 +13048,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880637",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Jelutong"
@@ -13072,7 +13072,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880638",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Jelutong"
@@ -13096,7 +13096,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880639",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Jalan Kayu"
@@ -13131,7 +13131,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880640",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Island View Estate"
@@ -13154,7 +13154,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880641",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Irau"
@@ -13177,7 +13177,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880642",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Institution Hill"
@@ -13200,7 +13200,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880643",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Inner Roads"
@@ -13226,7 +13226,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880644",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Hun Yeang"
@@ -13249,7 +13249,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880645",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Hume Heights"
@@ -13272,7 +13272,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880646",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Huat Choe"
@@ -13295,7 +13295,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880647",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Ho Tong Jen Estate"
@@ -13319,7 +13319,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880648",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Horseshoe Reef"
@@ -13343,7 +13343,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880649",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Hong Kong Park"
@@ -13366,7 +13366,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880650",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Hong Kah"
@@ -13389,7 +13389,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880651",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Holland Village"
@@ -13412,7 +13412,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880652",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Holland Grove Park"
@@ -13435,7 +13435,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880653",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Telok Hokian"
@@ -13459,7 +13459,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880654",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Hoe San Estate"
@@ -13483,7 +13483,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880655",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Herald Rock"
@@ -13506,7 +13506,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880656",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Henderson Shoal"
@@ -13529,7 +13529,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880657",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Heap Guan Village"
@@ -13552,7 +13552,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880658",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Hantu"
@@ -13576,7 +13576,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880659",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Keppel"
@@ -13599,7 +13599,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880660",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Hantu"
@@ -13622,7 +13622,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880661",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Haji Isa"
@@ -13646,7 +13646,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880662",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Keramat Habib Noor"
@@ -13669,7 +13669,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880663",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Keramat Habib Ismail"
@@ -13692,7 +13692,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880664",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Gul"
@@ -13715,7 +13715,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880665",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Grave Hill"
@@ -13738,7 +13738,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880666",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Goodwood Hill"
@@ -13761,7 +13761,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880667",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Glendinning Passage"
@@ -13785,7 +13785,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880668",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Geylang"
@@ -13808,7 +13808,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880669",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Geylang River"
@@ -13832,7 +13832,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880670",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Geylang"
@@ -13866,7 +13866,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880671",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Gedong"
@@ -13889,7 +13889,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880672",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Gedong"
@@ -13913,7 +13913,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880673",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Batu Gajah"
@@ -13936,7 +13936,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880674",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Fuyong Estate"
@@ -13959,7 +13959,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880675",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Frankel Estate"
@@ -13982,7 +13982,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880676",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Fort Canning Hill"
@@ -14005,7 +14005,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880677",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Fisherman Bank"
@@ -14028,7 +14028,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880678",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Felkin Spit"
@@ -14051,7 +14051,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880679",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Fan Shoal"
@@ -14074,7 +14074,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880680",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Fairy Point"
@@ -14097,7 +14097,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880681",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Mount Faber II"
@@ -14120,7 +14120,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880682",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Ewart Park"
@@ -14143,7 +14143,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880683",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Mount Emily"
@@ -14166,7 +14166,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880684",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Mount Embiah"
@@ -14189,7 +14189,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880685",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Mount Elizabeth"
@@ -14212,7 +14212,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880686",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Eden Park"
@@ -14235,7 +14235,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880687",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Eden Hall"
@@ -14258,7 +14258,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880688",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Mount Echo"
@@ -14281,7 +14281,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880689",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "East Lagoon"
@@ -14305,7 +14305,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880690",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "East Coast Park"
@@ -14328,7 +14328,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880691",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Telok Durian"
@@ -14352,7 +14352,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880692",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Dunearn Estate"
@@ -14375,7 +14375,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880693",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Dockyard Reach"
@@ -14399,7 +14399,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880694",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Denman Shoals"
@@ -14422,7 +14422,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880695",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Dekar"
@@ -14446,7 +14446,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880696",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Dekar"
@@ -14470,7 +14470,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880697",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Damar Laut"
@@ -14493,7 +14493,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880698",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Da"
@@ -14516,7 +14516,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880699",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Cyrene Reefs"
@@ -14540,7 +14540,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880700",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Clementi Park"
@@ -14564,7 +14564,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880701",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Chye Kay"
@@ -14599,7 +14599,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880702",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Chong Pang"
@@ -14634,7 +14634,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880703",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Chombun"
@@ -14657,7 +14657,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880704",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Choa Chu Kang"
@@ -14681,7 +14681,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880705",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Choa Chu Kang"
@@ -14701,7 +14701,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880706",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong China"
@@ -14724,7 +14724,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880707",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai China"
@@ -14748,7 +14748,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880708",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai China"
@@ -14772,7 +14772,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880709",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Chik Manya"
@@ -14796,7 +14796,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880710",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Chik Abu"
@@ -14820,7 +14820,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880711",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Chia Tong Quah Estate"
@@ -14854,7 +14854,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880712",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Chia Keng"
@@ -14889,7 +14889,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880713",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Chew Boon Lay Estate"
@@ -14913,7 +14913,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880714",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bukit Chermin"
@@ -14936,7 +14936,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880715",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Chenting"
@@ -14959,7 +14959,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880716",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Che Mat"
@@ -14983,7 +14983,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880717",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Chek Mat Noh"
@@ -15007,7 +15007,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880718",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Chek Jawa"
@@ -15030,7 +15030,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880719",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Che Kamis"
@@ -15054,7 +15054,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880720",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Changi Beach"
@@ -15078,7 +15078,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880721",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Changi"
@@ -15101,7 +15101,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880722",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Changi"
@@ -15125,7 +15125,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880723",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Changi Village"
@@ -15160,7 +15160,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880724",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Changi"
@@ -15183,7 +15183,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880725",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Singapore Changi Airport"
@@ -15208,7 +15208,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880726",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Fort Canning"
@@ -15232,7 +15232,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880727",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Camden Park"
@@ -15255,7 +15255,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880728",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Calder Harbour"
@@ -15281,7 +15281,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880729",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Caldecott Hill Estate"
@@ -15304,7 +15304,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880730",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Butun"
@@ -15327,7 +15327,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880731",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Terumbu Busong"
@@ -15351,7 +15351,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880732",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Busing"
@@ -15374,7 +15374,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880733",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Buran"
@@ -15397,7 +15397,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880734",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Buona Vista"
@@ -15431,7 +15431,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880735",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Buntu Kechil"
@@ -15455,7 +15455,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880736",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Buloh Kechil"
@@ -15479,7 +15479,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880737",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Buloh"
@@ -15502,7 +15502,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880738",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Buloh"
@@ -15525,7 +15525,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880739",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bulim"
@@ -15548,7 +15548,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880740",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Bukum Kechil"
@@ -15571,7 +15571,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880741",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Bukum"
@@ -15594,7 +15594,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880742",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Selat Bukum"
@@ -15618,7 +15618,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880743",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Bukum"
@@ -15641,7 +15641,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880744",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bukit Timah Estate"
@@ -15664,7 +15664,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880745",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bukit Timah Railway Station"
@@ -15688,7 +15688,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880746",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bukit Sembawang Estate"
@@ -15722,7 +15722,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880747",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bukit Sembawang Estate"
@@ -15756,7 +15756,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880748",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bukit Sembawang Estate"
@@ -15790,7 +15790,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880749",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bukit Sembawang Estate"
@@ -15813,7 +15813,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880750",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bukit Merah Estate"
@@ -15836,7 +15836,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880751",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bukit Mandai Village"
@@ -15871,7 +15871,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880752",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Buaya"
@@ -15894,7 +15894,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880753",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bukit Brown"
@@ -15917,7 +15917,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880754",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Beting Bronok"
@@ -15941,7 +15941,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880755",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bright Hill Crescent"
@@ -15976,7 +15976,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880756",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Brickworks Estate"
@@ -15999,7 +15999,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880757",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Brani Shoals"
@@ -16022,7 +16022,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880758",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Brani"
@@ -16045,7 +16045,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880759",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Braddell Hill"
@@ -16068,7 +16068,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880760",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Braddell Heights Estate"
@@ -16091,7 +16091,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880761",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Boon Lay"
@@ -16126,7 +16126,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880762",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Blukar"
@@ -16150,7 +16150,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880763",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Blukang Kechil"
@@ -16174,7 +16174,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880764",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Blukang"
@@ -16198,7 +16198,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880765",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Blangah Bay West"
@@ -16222,7 +16222,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880766",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Blakang Mati"
@@ -16246,7 +16246,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880767",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Biola"
@@ -16269,7 +16269,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880768",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bin Tong Park"
@@ -16292,7 +16292,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880769",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Mount Bijou"
@@ -16315,7 +16315,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880770",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bian San and Seng Ngiap Estate"
@@ -16339,7 +16339,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880771",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Besar"
@@ -16363,7 +16363,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880772",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bukit Besar"
@@ -16386,7 +16386,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880773",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Berlayar"
@@ -16409,7 +16409,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880774",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bukit Berlayar"
@@ -16432,7 +16432,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880775",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Berkas"
@@ -16455,7 +16455,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880776",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Berih"
@@ -16479,7 +16479,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880777",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Berhala Reping"
@@ -16502,7 +16502,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880778",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Berembang"
@@ -16526,7 +16526,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880779",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Benwi"
@@ -16549,7 +16549,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880780",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Benoi Yantu"
@@ -16573,7 +16573,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880781",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Bendul"
@@ -16597,7 +16597,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880782",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Telok Bendera"
@@ -16621,7 +16621,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880783",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Belang"
@@ -16645,7 +16645,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880784",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Batu Belalai"
@@ -16668,7 +16668,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880785",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Bedok"
@@ -16692,7 +16692,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880786",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bedok"
@@ -16715,7 +16715,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880787",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pedra Branca"
@@ -16738,7 +16738,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880788",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Batu Pengkalan Pakau"
@@ -16761,7 +16761,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880789",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Batu Koyok"
@@ -16784,7 +16784,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880790",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Batu Kekek"
@@ -16807,7 +16807,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880791",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Batu Kekek"
@@ -16831,7 +16831,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880792",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Batu Gajah"
@@ -16854,7 +16854,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880793",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Batu Gajah"
@@ -16877,7 +16877,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880794",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bukit Batok"
@@ -16900,7 +16900,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880795",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Banta Tengeh"
@@ -16935,7 +16935,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880796",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Bangkong"
@@ -16959,7 +16959,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880797",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Bang Beng"
@@ -16982,7 +16982,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880798",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Balai"
@@ -17005,7 +17005,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880799",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Balai"
@@ -17028,7 +17028,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880800",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Bakau Payong"
@@ -17051,7 +17051,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880801",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Bakau"
@@ -17074,7 +17074,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880802",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Bajau Kanan"
@@ -17098,7 +17098,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880803",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bajau Estate"
@@ -17121,7 +17121,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880804",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Bajau"
@@ -17145,7 +17145,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880805",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Bajau"
@@ -17168,7 +17168,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880806",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Busong Bajau"
@@ -17191,7 +17191,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880807",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bajau"
@@ -17211,7 +17211,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880808",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Ayer Raja"
@@ -17235,7 +17235,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880809",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Telok Ayer Merbau"
@@ -17259,7 +17259,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880810",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Ayer Merbau"
@@ -17282,7 +17282,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880811",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Ayer Gemuruh"
@@ -17306,7 +17306,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880812",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Istana Ayer Gemuruh"
@@ -17330,7 +17330,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880813",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Ayer Gemuruh"
@@ -17353,7 +17353,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880814",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Ayer Chawan"
@@ -17377,7 +17377,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880815",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Ayer Chawan"
@@ -17400,7 +17400,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880816",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Telok Ayer Brani"
@@ -17424,7 +17424,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880817",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Asam"
@@ -17448,7 +17448,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880818",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Ardmore Flats"
@@ -17471,7 +17471,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880819",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Api Api"
@@ -17495,7 +17495,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880820",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Angler Bank"
@@ -17518,7 +17518,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880821",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Anak Pulau"
@@ -17541,7 +17541,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880822",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Ama Keng"
@@ -17576,7 +17576,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880823",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Alligator Shoal"
@@ -17599,7 +17599,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880824",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Alexandra Canal"
@@ -17623,7 +17623,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880825",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Alexandra Estate"
@@ -17646,7 +17646,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880826",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Alang Perimbi"
@@ -17669,7 +17669,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880827",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Ajax Shoal"
@@ -17692,7 +17692,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1880828",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Aik Hong and Aik Chiang Estate"
@@ -17727,7 +17727,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880829",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Adelphi Park Estate"
@@ -17750,7 +17750,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880830",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Batu Addis"
@@ -17773,7 +17773,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1880831",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Adam Park"
@@ -17796,7 +17796,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880832",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Telok Achih"
@@ -17820,7 +17820,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1880833",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Achih"
@@ -17844,7 +17844,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1881620",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Jurong Basin"
@@ -17870,7 +17870,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1881621",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Pesek Kecil"
@@ -17893,7 +17893,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1881622",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Selat Ayer Chawan"
@@ -17917,7 +17917,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1881623",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Selat Ayer Merbau"
@@ -17941,7 +17941,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1881624",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Benoi Basin"
@@ -17967,7 +17967,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1881625",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Selat Meskol"
@@ -17991,7 +17991,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1881626",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "East Jurong Fairway"
@@ -18015,7 +18015,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1881627",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sinki Fairway"
@@ -18039,7 +18039,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1881628",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Terumbu Menalung"
@@ -18063,7 +18063,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1881629",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Terumbu Bemban"
@@ -18087,7 +18087,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1881630",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Beting Bemban Besar"
@@ -18111,7 +18111,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1881631",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Selat Pauh"
@@ -18135,7 +18135,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1881632",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Selat Pauh Anchorage"
@@ -18161,7 +18161,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1881633",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Terumbu Raya"
@@ -18185,7 +18185,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1881634",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Terumbu Pempang Laut"
@@ -18209,7 +18209,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1881635",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Terumbu Pempang Tengah"
@@ -18233,7 +18233,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1881636",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Terumbu Pempang Darat"
@@ -18257,7 +18257,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1881637",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Monggok Gerita"
@@ -18280,7 +18280,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1881638",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Terumbu Pandan"
@@ -18304,7 +18304,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1881639",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Monggok Tengelam"
@@ -18327,7 +18327,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1881640",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Terumbu Serebut"
@@ -18351,7 +18351,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1881641",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Terumbu Retan Darat"
@@ -18375,7 +18375,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1881642",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Retan Laut"
@@ -18398,7 +18398,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1881643",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pasir Panjang Fairway"
@@ -18422,7 +18422,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1881644",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Terumbu Selegi"
@@ -18446,7 +18446,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1881645",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "West Keppel Fairway"
@@ -18470,7 +18470,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1881646",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Jong Fairway"
@@ -18494,7 +18494,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1881647",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Terumbu Bukom"
@@ -18518,7 +18518,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1881648",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Batu Tangelam"
@@ -18541,7 +18541,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1881649",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Batu Kopi"
@@ -18564,7 +18564,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1881650",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Anak Bukum"
@@ -18587,7 +18587,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1881651",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Terumbu Semakau"
@@ -18611,7 +18611,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1881652",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Siloso Beach"
@@ -18635,7 +18635,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1881653",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sisters Shoal"
@@ -18658,7 +18658,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1881654",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Beting Kapal"
@@ -18681,7 +18681,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1881655",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Terumbu Bayan"
@@ -18705,7 +18705,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1881916",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Alert Shoal"
@@ -18729,7 +18729,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1881917",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Ayer Raja Industrial Estate"
@@ -18752,7 +18752,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1881918",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Ayer Raja New Town"
@@ -18775,7 +18775,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1881919",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bishan New Town"
@@ -18798,7 +18798,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1881920",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Botanic Gardens"
@@ -18821,7 +18821,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1881921",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bukit Batok New Town"
@@ -18844,7 +18844,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1881922",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bukit Ho Swee Estate"
@@ -18867,7 +18867,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1881923",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Eunos Industrial Estate"
@@ -18890,7 +18890,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1881924",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Farrer Park"
@@ -18914,7 +18914,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1881925",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Fort Siloso"
@@ -18938,7 +18938,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1881926",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Haw Par Villa"
@@ -18961,7 +18961,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1881946",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Henderson Estate"
@@ -18984,7 +18984,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1881947",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Hong Lim Park"
@@ -19007,7 +19007,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1881948",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Hougang New Town"
@@ -19030,7 +19030,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1881949",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Istana Negara"
@@ -19054,7 +19054,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1881950",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Johore Causeway"
@@ -19074,7 +19074,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1881951",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Jurong Bird Park"
@@ -19097,7 +19097,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1881952",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Jurong East New Town"
@@ -19131,7 +19131,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1881953",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Jurong Town"
@@ -19166,7 +19166,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1881954",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Jurong Industrial Estate"
@@ -19189,7 +19189,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1881955",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Jurong West New Town"
@@ -19223,7 +19223,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1881956",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Jurong Wharf"
@@ -19243,7 +19243,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1881957",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kaki Bukit Estate"
@@ -19266,7 +19266,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1881958",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kallang Basin Industrial Estate"
@@ -19289,7 +19289,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1881959",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kallang Park"
@@ -19312,7 +19312,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1881960",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kallang Park Industrial Estate"
@@ -19335,7 +19335,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1881961",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kallang Way Industrial Estate"
@@ -19358,7 +19358,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1881962",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Ampat Industrial Estate"
@@ -19381,7 +19381,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1881963",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Tiong Bahru Industrial Estate"
@@ -19404,7 +19404,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1881964",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Ubi Industrial Park"
@@ -19427,7 +19427,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1881965",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kandang Kerbau Bridge"
@@ -19447,7 +19447,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1881966",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Katong Park"
@@ -19470,7 +19470,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1881967",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kent Ridge"
@@ -19493,7 +19493,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1881968",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Krangji Industrial Estate"
@@ -19516,7 +19516,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1881969",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kranji Dam"
@@ -19536,7 +19536,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1881970",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kranji Nature Reserve"
@@ -19559,7 +19559,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1881971",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kranji Reservoir"
@@ -19583,7 +19583,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1881972",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Labrador Nature Reserve"
@@ -19606,7 +19606,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1881998",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Aljunied"
@@ -19640,7 +19640,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1881999",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Anson"
@@ -19674,7 +19674,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882000",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bras Basah"
@@ -19708,7 +19708,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882001",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bukit Batok"
@@ -19742,7 +19742,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882002",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bukit Ho Swee"
@@ -19776,7 +19776,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882003",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bukit Merah"
@@ -19810,7 +19810,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882004",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bukit Panjang"
@@ -19844,7 +19844,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882005",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bukit Timah"
@@ -19878,7 +19878,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882006",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Cairnhill"
@@ -19912,7 +19912,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882007",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Choa Chu Kang"
@@ -19946,7 +19946,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882008",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Crawford"
@@ -19980,7 +19980,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882009",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Farrer Park"
@@ -20014,7 +20014,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882010",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Geylang East"
@@ -20048,7 +20048,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882011",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Geylang Serai"
@@ -20082,7 +20082,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882012",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Geylang West"
@@ -20116,7 +20116,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882013",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Henderson"
@@ -20150,7 +20150,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882014",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Jalan Besar"
@@ -20184,7 +20184,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882015",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Jalan Kayu"
@@ -20218,7 +20218,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882016",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Joo Chiat"
@@ -20252,7 +20252,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882017",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Jurong"
@@ -20286,7 +20286,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882018",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kallang"
@@ -20320,7 +20320,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882019",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Chai Chee"
@@ -20354,7 +20354,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882020",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Glam"
@@ -20388,7 +20388,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882021",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Kapor"
@@ -20422,7 +20422,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882022",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Kembangan"
@@ -20456,7 +20456,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882023",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Ubi"
@@ -20490,7 +20490,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882024",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Katong"
@@ -20524,7 +20524,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882025",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kim Keat"
@@ -20558,7 +20558,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882026",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kim Seng"
@@ -20592,7 +20592,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882027",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kreta Ayer"
@@ -20626,7 +20626,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882028",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kuo Chuan"
@@ -20660,7 +20660,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882029",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Leng Kee"
@@ -20694,7 +20694,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882030",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Upper Peirce Reservoir"
@@ -20718,7 +20718,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882031",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Lower Seletar Reservoir"
@@ -20742,7 +20742,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882032",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Loyang Industrial Estate"
@@ -20765,7 +20765,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882033",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "MacPherson"
@@ -20800,7 +20800,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882034",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "MacRitchie Reservoir Park"
@@ -20823,7 +20823,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882035",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Marina Centre"
@@ -20846,7 +20846,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882036",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Marina East"
@@ -20869,7 +20869,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882037",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Marina Hill"
@@ -20892,7 +20892,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882038",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Marina South"
@@ -20915,7 +20915,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882039",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Merdeka Bridge"
@@ -20935,7 +20935,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882040",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Moulmein"
@@ -20969,7 +20969,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882041",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Mountbatten"
@@ -21003,7 +21003,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882042",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Murai Reservoir"
@@ -21027,7 +21027,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882043",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Nee Soon"
@@ -21061,7 +21061,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1882044",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Outram Park"
@@ -21084,7 +21084,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882045",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Seringat Kecil"
@@ -21107,7 +21107,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882046",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pandan Reservoir"
@@ -21131,7 +21131,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882047",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pasir Panjang"
@@ -21165,7 +21165,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882048",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Paya Lebar"
@@ -21199,7 +21199,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882049",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Upper Seletar Reservoir"
@@ -21223,7 +21223,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882050",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pemalang"
@@ -21247,7 +21247,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882073",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Potong Pasir"
@@ -21281,7 +21281,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882074",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Poyan Reservoir"
@@ -21305,7 +21305,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882075",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Punggol"
@@ -21339,7 +21339,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882076",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Queen Elizabeth Walk"
@@ -21362,7 +21362,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882077",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Queenstown"
@@ -21396,7 +21396,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882078",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Raffles Lighthouse"
@@ -21416,7 +21416,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882079",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Redhill Industrial Estate"
@@ -21439,7 +21439,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882080",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "River Valley"
@@ -21473,7 +21473,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882081",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Rochor"
@@ -21507,7 +21507,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882082",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Lanchar"
@@ -21531,7 +21531,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882083",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Pak Bekang"
@@ -21555,7 +21555,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882084",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Permatang"
@@ -21579,7 +21579,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882085",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Rengkam"
@@ -21603,7 +21603,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882086",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Seminei"
@@ -21627,7 +21627,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882087",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sarimbun Reservoir"
@@ -21651,7 +21651,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882088",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sawa Pemalang"
@@ -21674,7 +21674,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882089",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Science Park"
@@ -21697,7 +21697,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882090",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sebarok Channel"
@@ -21721,7 +21721,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882091",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Selat Berkas"
@@ -21745,7 +21745,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882092",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Selat Biola"
@@ -21769,7 +21769,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882093",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Selat Pawai"
@@ -21793,7 +21793,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882094",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Selat Tanjong Hakim"
@@ -21817,7 +21817,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882096",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Seletar Industrial Estate"
@@ -21840,7 +21840,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882097",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sembawang"
@@ -21874,7 +21874,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882098",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Senoko Industrial Estate"
@@ -21897,7 +21897,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882099",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sepoy Lines"
@@ -21931,7 +21931,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882100",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Serangoon Garden"
@@ -21965,7 +21965,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1882101",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Serangoon New Town"
@@ -21988,7 +21988,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882102",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Siglap Park"
@@ -22011,7 +22011,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1882103",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Simei New Town"
@@ -22034,7 +22034,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882104",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sims Avenue Industrial Estate"
@@ -22057,7 +22057,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882105",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sin Ming Industrial Estate"
@@ -22080,7 +22080,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882106",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Singapore Zoological Gardens"
@@ -22103,7 +22103,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882107",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Saint Michael’s Estate"
@@ -22138,7 +22138,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882108",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Saint Michael’s Industrial Estate"
@@ -22161,7 +22161,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882109",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Stamford"
@@ -22195,7 +22195,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882110",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Stamford Bridge"
@@ -22215,7 +22215,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882111",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sultan Shoal Lighthouse"
@@ -22235,7 +22235,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882112",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungei Kadut Industrial Estate"
@@ -22258,7 +22258,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882113",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungei Seletar Dam"
@@ -22278,7 +22278,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882114",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tampines"
@@ -22312,7 +22312,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1882115",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tampines New Town"
@@ -22335,7 +22335,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882116",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanah Merah Beach"
@@ -22359,7 +22359,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882117",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanglin"
@@ -22393,7 +22393,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882118",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanglin Halt"
@@ -22428,7 +22428,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882119",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Pagar"
@@ -22462,7 +22462,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882120",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Telok Ayer"
@@ -22496,7 +22496,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882121",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Telok Blangah"
@@ -22530,7 +22530,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882122",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Telok Blangah Industrial Estate"
@@ -22553,7 +22553,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882123",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tengeh Reservoir"
@@ -22577,7 +22577,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882124",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Terumbu Berkas"
@@ -22601,7 +22601,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882125",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Terumbu Buntal"
@@ -22625,7 +22625,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882126",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Terumbu Jambi"
@@ -22649,7 +22649,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882127",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Terumbu Jarat"
@@ -22673,7 +22673,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882128",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Terumbu Mait"
@@ -22697,7 +22697,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882129",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Terumbu Palat"
@@ -22721,7 +22721,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882130",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Terumbu Pemalang Besar"
@@ -22745,7 +22745,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882131",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Terumbu Pemalang Kechil"
@@ -22769,7 +22769,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882132",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Terumbu Penyalai"
@@ -22793,7 +22793,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882133",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Terumbu Sechirit"
@@ -22817,7 +22817,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882135",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Batu Balok"
@@ -22840,7 +22840,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882136",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Berhala Kuda"
@@ -22863,7 +22863,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882137",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Berkat"
@@ -22886,7 +22886,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882139",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong China"
@@ -22909,7 +22909,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882140",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Genting"
@@ -22932,7 +22932,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882143",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Rimau"
@@ -22955,7 +22955,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882144",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "The Sisters"
@@ -22978,7 +22978,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882145",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Thomson"
@@ -23012,7 +23012,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882146",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tiong Bahru"
@@ -23046,7 +23046,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882147",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Toa Payoh"
@@ -23080,7 +23080,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882148",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Toa Payoh Industrial Estate"
@@ -23103,7 +23103,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882149",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Triton Shoal"
@@ -23126,7 +23126,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882150",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Ulu Pandan"
@@ -23160,7 +23160,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882151",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Upper Serangoon"
@@ -23194,7 +23194,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882152",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "West Point Garden"
@@ -23217,7 +23217,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882153",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Whampoa"
@@ -23251,7 +23251,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1882154",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Xilin Estate"
@@ -23274,7 +23274,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882155",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Yishun New Town"
@@ -23309,7 +23309,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882246",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Poyan Dyke"
@@ -23329,7 +23329,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882247",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pergam Dyke"
@@ -23349,7 +23349,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882248",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sarimbun I"
@@ -23369,7 +23369,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882249",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Karang Dyke"
@@ -23389,7 +23389,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882250",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "South Sarimbum Dyke"
@@ -23409,7 +23409,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882251",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "North Sarimbum Dyke"
@@ -23429,7 +23429,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882252",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sarimbun II"
@@ -23449,7 +23449,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882253",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Lim Chu Kang"
@@ -23484,7 +23484,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882254",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Lim Chu Kang"
@@ -23504,7 +23504,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882255",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kranji Reservoir Park"
@@ -23528,7 +23528,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882314",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kranji War Memorial"
@@ -23551,7 +23551,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882316",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Woodlands New Town"
@@ -23586,7 +23586,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882317",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Marsiling Cau 3T"
@@ -23606,7 +23606,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882318",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Mandai Village"
@@ -23641,7 +23641,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882320",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Seng Kee Quarry"
@@ -23664,7 +23664,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882323",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Phoenix Park"
@@ -23688,7 +23688,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882324",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bukit Panjang Estate"
@@ -23722,7 +23722,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882325",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Upper Mandai III"
@@ -23742,7 +23742,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882326",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Upper Mandai IV"
@@ -23762,7 +23762,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882327",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Aik Hong and Aik Chiang Estate"
@@ -23796,7 +23796,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882328",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Upper Mandai II"
@@ -23816,7 +23816,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882331",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Public Utilities Board Pipeline"
@@ -23840,7 +23840,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882332",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Upper Mandai I"
@@ -23860,7 +23860,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882333",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Mandai I"
@@ -23880,7 +23880,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882334",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Marsiling Industrial Estate"
@@ -23903,7 +23903,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882336",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Senoko Power Station"
@@ -23926,7 +23926,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882338",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sembawang Hospital"
@@ -23949,7 +23949,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882339",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sembawang Shipyard"
@@ -23972,7 +23972,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882340",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "King George VI Dock"
@@ -23998,7 +23998,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882341",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sembawang I"
@@ -24018,7 +24018,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882342",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Springleaf Park"
@@ -24052,7 +24052,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882343",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Seletar I"
@@ -24072,7 +24072,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882344",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Teacher’s Housing Estate"
@@ -24106,7 +24106,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882345",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bukit Sembawang Estate"
@@ -24140,7 +24140,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882361",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Seletar Reservoir Park"
@@ -24164,7 +24164,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882363",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Beaulieu Shoal"
@@ -24187,7 +24187,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882368",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sembawang Wharves"
@@ -24207,7 +24207,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882370",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Lowinger Reef"
@@ -24231,7 +24231,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882386",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Woodbridge Hospital and Institute of Mental Health"
@@ -24254,7 +24254,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882392",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Serangoon Sewage Treatment Works"
@@ -24274,7 +24274,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882398",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Punggol I"
@@ -24294,7 +24294,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882399",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bukit Sembawang Estate"
@@ -24328,7 +24328,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882401",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Serangoon"
@@ -24363,7 +24363,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882402",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kangkar"
@@ -24398,7 +24398,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882405",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Punggol"
@@ -24421,7 +24421,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882406",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Ponggol Point"
@@ -24444,7 +24444,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882408",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Punggol III"
@@ -24464,7 +24464,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882409",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Punggol V"
@@ -24484,7 +24484,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882427",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Tajam"
@@ -24504,7 +24504,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882428",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pasir Ris Hotel"
@@ -24527,7 +24527,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882429",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pasir Ris Beach Park"
@@ -24551,7 +24551,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882430",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pasir Ris Beach"
@@ -24575,7 +24575,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882431",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Cau 5T Changi"
@@ -24595,7 +24595,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882432",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Ubin II"
@@ -24615,7 +24615,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882434",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Changi Point"
@@ -24638,7 +24638,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882435",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Changi Beach Park"
@@ -24662,7 +24662,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882453",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Murai Dam"
@@ -24682,7 +24682,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882475",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Fisherman Bank"
@@ -24706,7 +24706,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882479",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Merlin Rock"
@@ -24729,7 +24729,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882483",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Outer Rock"
@@ -24752,7 +24752,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882484",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tekong Kechil"
@@ -24775,7 +24775,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882485",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Tekong VIII"
@@ -24795,7 +24795,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882486",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Tekong III"
@@ -24815,7 +24815,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882487",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Tekong Reservoir"
@@ -24839,7 +24839,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882488",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Tekong V"
@@ -24859,7 +24859,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882489",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Tekong VI"
@@ -24879,7 +24879,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882490",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Permatang"
@@ -24903,7 +24903,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882491",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Damien"
@@ -24926,7 +24926,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882506",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Nanyang Cau 2T"
@@ -24946,7 +24946,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882507",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Chinese Garden"
@@ -24969,7 +24969,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882508",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Japanese Garden"
@@ -24992,7 +24992,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882509",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tropical Garden"
@@ -25015,7 +25015,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882510",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Jurong Hospital"
@@ -25038,7 +25038,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1882511",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Boon Lay Resettlement Area"
@@ -25061,7 +25061,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882512",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Jurong Hill"
@@ -25084,7 +25084,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882513",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Singapore Science Centre"
@@ -25104,7 +25104,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882514",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Jurong Shipyard"
@@ -25127,7 +25127,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882515",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Gul Basin"
@@ -25153,7 +25153,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882516",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Shipyard Road"
@@ -25179,7 +25179,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882517",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Southern Tuas Basin"
@@ -25205,7 +25205,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882518",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Merbau"
@@ -25229,7 +25229,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882519",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pan United Shipyard"
@@ -25252,7 +25252,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882520",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tuas Bay"
@@ -25276,7 +25276,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882521",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "West Jurong Fairway"
@@ -25300,7 +25300,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882522",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "West Jurong Anchorage"
@@ -25326,7 +25326,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882523",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pesek Fairway"
@@ -25350,7 +25350,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882524",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Mobil Oil Depot"
@@ -25373,7 +25373,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882525",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Mobil Oil Refinery"
@@ -25396,7 +25396,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882526",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tuas Channel"
@@ -25420,7 +25420,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882527",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Long Shoal"
@@ -25443,7 +25443,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882529",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Ahmad Ibrahim Road Highway Strip"
@@ -25468,7 +25468,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882530",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sembawang"
@@ -25493,7 +25493,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882531",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Singapore Highway Strip Bedok"
@@ -25517,7 +25517,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882532",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Singapore Highway Strip Pioneer"
@@ -25542,7 +25542,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882534",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Singapore Tuas West Highway"
@@ -25567,7 +25567,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882538",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Buloh Besar"
@@ -25591,7 +25591,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882539",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Buloh"
@@ -25615,7 +25615,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882541",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Bedok"
@@ -25639,7 +25639,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882542",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Malang Siajar"
@@ -25662,7 +25662,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882544",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tuas Jetty"
@@ -25682,7 +25682,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882545",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Raffles Marina"
@@ -25706,7 +25706,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882548",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bukit Gombak"
@@ -25729,7 +25729,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1882549",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bamboo Grove Park"
@@ -25752,7 +25752,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882550",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Seng Chew Quarry"
@@ -25775,7 +25775,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882551",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Gammon Granite Quarry"
@@ -25798,7 +25798,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1882552",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Soo Chow Garden"
@@ -25821,7 +25821,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1882553",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Thomson Garden Estate"
@@ -25844,7 +25844,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1882554",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Mayflower Estate"
@@ -25867,7 +25867,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882555",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Ang Mo Kio II"
@@ -25887,7 +25887,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882556",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Ang Mo Kio VI"
@@ -25907,7 +25907,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1882557",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Thomson Ridge Estate"
@@ -25930,7 +25930,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1882558",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Thomson Park"
@@ -25953,7 +25953,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1882559",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tai Hwan Gardens"
@@ -25976,7 +25976,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882560",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Ang Mo Kio Park"
@@ -26000,7 +26000,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882561",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Ang Mo Kio III"
@@ -26020,7 +26020,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882686",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Serangoon Park"
@@ -26044,7 +26044,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882687",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Toa Payoh Hospital"
@@ -26067,7 +26067,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882688",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tan Tock Seng Hospital"
@@ -26090,7 +26090,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1882689",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Goldhill Gardens"
@@ -26113,7 +26113,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1882690",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Watten Estate"
@@ -26136,7 +26136,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1882691",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Hillcrest Park"
@@ -26159,7 +26159,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1882692",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Lucky Park"
@@ -26182,7 +26182,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1882693",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Brizay Park"
@@ -26205,7 +26205,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1882694",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Ban Guan Park"
@@ -26228,7 +26228,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1882695",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Shamrock Park"
@@ -26251,7 +26251,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1882696",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Coronation Gardens"
@@ -26274,7 +26274,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1882697",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Rebecca Park"
@@ -26297,7 +26297,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882698",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Gimson School"
@@ -26320,7 +26320,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882699",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Ngee Ann Polytechnic"
@@ -26343,7 +26343,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1882700",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pandan Valley"
@@ -26366,7 +26366,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1882701",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Eng Khong Gardens"
@@ -26389,7 +26389,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1882702",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Hong Leong Garden"
@@ -26412,7 +26412,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1882703",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Faber Hills"
@@ -26435,7 +26435,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1882704",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sussex Estate"
@@ -26458,7 +26458,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882705",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "National University of Singapore"
@@ -26481,7 +26481,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1882706",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Ghim Moh"
@@ -26504,7 +26504,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1882707",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Chinese Gardens"
@@ -26527,7 +26527,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882708",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Alexandra Hospital"
@@ -26550,7 +26550,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882709",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Remand Prison"
@@ -26573,7 +26573,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1882710",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Chip Hock Garden"
@@ -26596,7 +26596,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1882711",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sommerville Estate"
@@ -26619,7 +26619,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1882712",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kimlin Park"
@@ -26642,7 +26642,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882713",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Singapore General Hospital"
@@ -26665,7 +26665,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1882714",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Dragon View Park"
@@ -26688,7 +26688,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1882715",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Delta Estate"
@@ -26711,7 +26711,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1882716",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "York Hill Estate"
@@ -26734,7 +26734,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1882717",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Silat Estate"
@@ -26757,7 +26757,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882718",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Saigon"
@@ -26780,7 +26780,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1882719",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Mount Emily Park"
@@ -26803,7 +26803,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1882720",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "People’s Park"
@@ -26826,7 +26826,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882721",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Fullerton Light House"
@@ -26846,7 +26846,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882722",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Marina Bay"
@@ -26870,7 +26870,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882723",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Anderson Bridge"
@@ -26890,7 +26890,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882724",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Clifford Pier"
@@ -26915,7 +26915,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882725",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "North Pier"
@@ -26940,7 +26940,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882726",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Fort Canning Reservoir"
@@ -26964,7 +26964,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882727",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Marina South City Park"
@@ -26988,7 +26988,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882728",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Marina Wharf"
@@ -27008,7 +27008,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882729",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Finger Pier"
@@ -27033,7 +27033,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882730",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "East Wharf"
@@ -27053,7 +27053,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882731",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Albert Dock"
@@ -27079,7 +27079,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882732",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Victoria Dock"
@@ -27105,7 +27105,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882733",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pearl’s Hill Reservoir"
@@ -27129,7 +27129,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882734",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Reef Brani"
@@ -27153,7 +27153,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882735",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "West Wharf"
@@ -27173,7 +27173,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882736",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Empire Dock"
@@ -27199,7 +27199,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882737",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Singapore Railway Station"
@@ -27223,7 +27223,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882738",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Mount Faber Scenic Park"
@@ -27247,7 +27247,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882739",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Mount Faber Cau 4T"
@@ -27270,7 +27270,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882740",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Queen’s Dock"
@@ -27296,7 +27296,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882741",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "King’s Dock"
@@ -27322,7 +27322,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882742",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Saint James Power Station"
@@ -27345,7 +27345,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882743",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Duran Darat"
@@ -27368,7 +27368,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882744",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "World Trade Center"
@@ -27388,7 +27388,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882745",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Woodbridge Hospital"
@@ -27411,7 +27411,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1882746",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Somapah Serangoon"
@@ -27434,7 +27434,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1882747",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Charlton Park"
@@ -27457,7 +27457,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1882748",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Lew Lian"
@@ -27480,7 +27480,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882749",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Siren"
@@ -27515,7 +27515,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1882750",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Peoples Garden"
@@ -27538,7 +27538,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1882751",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Hai Sing Park"
@@ -27561,7 +27561,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1882752",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Fish Farming Estate"
@@ -27584,7 +27584,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1882753",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Punggol Estate"
@@ -27607,7 +27607,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882754",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Teban II"
@@ -27627,7 +27627,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882755",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Changi Prison"
@@ -27650,7 +27650,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882756",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "South End Reservoir"
@@ -27674,7 +27674,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1882757",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bena Park"
@@ -27697,7 +27697,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1882758",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Wing Loong"
@@ -27720,7 +27720,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1882759",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Darat Nanas"
@@ -27743,7 +27743,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1882760",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "East View Garden"
@@ -27766,7 +27766,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1882761",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Harvey"
@@ -27789,7 +27789,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882762",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bedok Reservoir"
@@ -27813,7 +27813,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1882763",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kim Chuan"
@@ -27836,7 +27836,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1882764",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tai Kheng Gardens"
@@ -27859,7 +27859,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1882765",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Ah Soo Garden"
@@ -27882,7 +27882,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1882766",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Raya Garden"
@@ -27905,7 +27905,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1882767",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Quemoy Park"
@@ -27928,7 +27928,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1882768",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Happy Gardens"
@@ -27951,7 +27951,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1882769",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Chai Chee Estate"
@@ -27974,7 +27974,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1882770",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Siew Lim Park"
@@ -27997,7 +27997,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1882771",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bedok Village"
@@ -28020,7 +28020,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1882772",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bedok Garden"
@@ -28043,7 +28043,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1882773",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Tanah Merah Kechil"
@@ -28066,7 +28066,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1882774",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Lucky Hills"
@@ -28089,7 +28089,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1882775",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Sek Lim"
@@ -28112,7 +28112,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1882776",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Eastern Gardens"
@@ -28135,7 +28135,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882778",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Marine Parade"
@@ -28170,7 +28170,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1882779",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Rose Garden"
@@ -28193,7 +28193,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1882780",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Gay World Park"
@@ -28216,7 +28216,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882781",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Ular Reef"
@@ -28240,7 +28240,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882782",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Tekukor"
@@ -28260,7 +28260,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882783",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Tembakul"
@@ -28280,7 +28280,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882784",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Saint John’s East"
@@ -28300,7 +28300,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882785",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Subar Laut"
@@ -28320,7 +28320,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882786",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Subar Darat"
@@ -28340,7 +28340,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882787",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Jong"
@@ -28360,7 +28360,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1882788",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Sakeng"
@@ -28395,7 +28395,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882789",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Salu"
@@ -28415,7 +28415,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882790",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Sebarok"
@@ -28435,7 +28435,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882791",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Pawai"
@@ -28455,7 +28455,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882792",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bukit Lang Kuku"
@@ -28478,7 +28478,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882793",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bukit Berhala Kuda"
@@ -28501,7 +28501,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882794",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sungai Besar"
@@ -28525,7 +28525,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882795",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bukit Genting"
@@ -28548,7 +28548,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882796",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Senang"
@@ -28568,7 +28568,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882797",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bukit Batu Balok"
@@ -28591,7 +28591,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882798",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bukit Pak Bekang"
@@ -28614,7 +28614,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882799",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bukit Patrosumpak"
@@ -28637,7 +28637,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882800",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bukit Kelapa Tujoh Pokok"
@@ -28660,7 +28660,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882801",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bukit Prigi Kling"
@@ -28683,7 +28683,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882802",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Biola"
@@ -28703,7 +28703,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882803",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Telok Ratai"
@@ -28727,7 +28727,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882804",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sultan Fairway"
@@ -28751,7 +28751,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882805",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "West Raffles Passage"
@@ -28775,7 +28775,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882806",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "East Keppel Fairway"
@@ -28799,7 +28799,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882807",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sisters Fairway"
@@ -28823,7 +28823,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882873",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kallang Basin"
@@ -28847,7 +28847,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882874",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Saint Andrews Cathedral"
@@ -28870,7 +28870,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882875",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Southern Fairway"
@@ -28894,7 +28894,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882876",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Karang Hambat"
@@ -28917,7 +28917,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882877",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Monggok Sebarok"
@@ -28940,7 +28940,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882878",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Jambi South"
@@ -28964,7 +28964,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882879",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Jambi West"
@@ -28988,7 +28988,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882881",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Eastgate Wharf"
@@ -29008,7 +29008,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882896",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Central Lagoon"
@@ -29032,7 +29032,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882897",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Cruise Bay"
@@ -29058,7 +29058,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882898",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Berlayar Rock"
@@ -29081,7 +29081,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882899",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pasir Panjang Wharf"
@@ -29101,7 +29101,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882900",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Western Quarantine and Immigration Anchorage"
@@ -29127,7 +29127,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882901",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Western Working Anchorage"
@@ -29153,7 +29153,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882902",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Western Petroleum Anchorage A"
@@ -29179,7 +29179,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882903",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Western Reserved Anchorage"
@@ -29205,7 +29205,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882904",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pasir Panjang Coastal Anchorage"
@@ -29231,7 +29231,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882907",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sultan Shoal Petroleum Anchorage"
@@ -29257,7 +29257,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882908",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tuas Explosives Anchorage"
@@ -29283,7 +29283,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882909",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Liquefied Gas Carriers Anchorage"
@@ -29309,7 +29309,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882910",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Eastern Quarantine and Immigration Anchorage"
@@ -29335,7 +29335,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882911",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Red Cliff Shoal"
@@ -29358,7 +29358,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882912",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Pagar Terminal"
@@ -29385,7 +29385,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882913",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Eastern Fairway"
@@ -29409,7 +29409,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882914",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bedok Lighthouse"
@@ -29429,7 +29429,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882917",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Copper Channel"
@@ -29453,7 +29453,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882921",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Malang Orang"
@@ -29477,7 +29477,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882925",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Paktank Terminal"
@@ -29500,7 +29500,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1882927",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sultan Shoal Petroleum Anchorage B"
@@ -29526,7 +29526,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1883022",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Buran Channel"
@@ -29550,7 +29550,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1883024",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Beach"
@@ -29574,7 +29574,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1883026",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Western Roads"
@@ -29600,7 +29600,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1883028",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Meander Shoal"
@@ -29623,7 +29623,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1883029",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Chumpang Bay"
@@ -29647,7 +29647,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1883030",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Chermin Wharf"
@@ -29667,7 +29667,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1883031",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Berlayar Canal"
@@ -29691,7 +29691,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1883032",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Freyberg Channel"
@@ -29715,7 +29715,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1883033",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Water Boat Channel"
@@ -29739,7 +29739,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1883034",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Fairburn Channel"
@@ -29763,7 +29763,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1883035",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kuala Johor"
@@ -29787,7 +29787,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1883077",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Fernhill Gardens"
@@ -29810,7 +29810,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1883092",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "North Channel"
@@ -29834,7 +29834,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884113",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Thong Hoe"
@@ -29854,7 +29854,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884114",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Woodlands"
@@ -29874,7 +29874,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884202",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Causeway Shoal"
@@ -29897,7 +29897,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884203",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Woodlands Garden"
@@ -29921,7 +29921,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884204",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sembawang End Park"
@@ -29945,7 +29945,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884211",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Mayang"
@@ -29968,7 +29968,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884212",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Seletar"
@@ -29988,7 +29988,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884240",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Punggol Fishing Port"
@@ -30015,7 +30015,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884252",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Changi Creek Reservoir"
@@ -30039,7 +30039,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884253",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Sekudu"
@@ -30059,7 +30059,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884254",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Ubi Beach"
@@ -30083,7 +30083,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884261",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Outward Bound School"
@@ -30106,7 +30106,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884262",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Ubin"
@@ -30126,7 +30126,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884263",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Prawn Pond"
@@ -30150,7 +30150,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884264",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Koyok"
@@ -30170,7 +30170,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884281",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Public Utilities Board Western Catchment Area"
@@ -30193,7 +30193,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884283",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pioneer"
@@ -30213,7 +30213,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884284",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tuas"
@@ -30233,7 +30233,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884285",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Jurong Hill Park"
@@ -30256,7 +30256,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884286",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Jurong Town Hall"
@@ -30276,7 +30276,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884287",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Jurong Lake"
@@ -30300,7 +30300,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884296",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bukit Batok Nature Park"
@@ -30323,7 +30323,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884297",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bukit Batok Town Park"
@@ -30347,7 +30347,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884298",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bishan Park"
@@ -30371,7 +30371,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1884299",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tian Guan Estate"
@@ -30394,7 +30394,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1884300",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tiong Guan Estate"
@@ -30417,7 +30417,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884302",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Marina Park"
@@ -30441,7 +30441,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884303",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sims Avenue"
@@ -30461,7 +30461,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884304",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pierce Triangulation Station"
@@ -30481,7 +30481,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884305",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kwong Wai Shiu Hospital"
@@ -30504,7 +30504,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884306",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Gold Hill"
@@ -30527,7 +30527,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884307",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Java Park"
@@ -30551,7 +30551,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884309",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kim Seng"
@@ -30571,7 +30571,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884310",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Telok Blangah Hill Park"
@@ -30595,7 +30595,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884311",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Dangerous Goods Anchorage"
@@ -30621,7 +30621,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884312",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Queenway"
@@ -30641,7 +30641,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884313",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Nus"
@@ -30661,7 +30661,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884314",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "National Youth Leadership Training Centre"
@@ -30684,7 +30684,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884315",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kent Ridge Park"
@@ -30708,7 +30708,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884316",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Clementi"
@@ -30728,7 +30728,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884317",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Horsburgh Lighthouse"
@@ -30748,7 +30748,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884326",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Eastern Petroleum Anchorage A"
@@ -30774,7 +30774,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884327",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Eastern Special Purposes Anchorage B"
@@ -30800,7 +30800,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884328",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Eastern Petroleum Anchorage C"
@@ -30826,7 +30826,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884329",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Eastern Special Purposes Anchorage A"
@@ -30852,7 +30852,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884330",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Laid-Up Vessels Anchorage"
@@ -30878,7 +30878,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884331",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Small Craft Anchorage"
@@ -30904,7 +30904,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884332",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Explosives Anchorage"
@@ -30930,7 +30930,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884333",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Eastern Working Anchorage"
@@ -30956,7 +30956,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884334",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Corridor Anchorage"
@@ -30982,7 +30982,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884335",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Marine Parade"
@@ -31002,7 +31002,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884336",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "East Shore Hospital"
@@ -31025,7 +31025,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884337",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Eunos"
@@ -31045,7 +31045,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884338",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Aljunied Park"
@@ -31069,7 +31069,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884340",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Defu Industrial Estate"
@@ -31092,7 +31092,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884341",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Hougang"
@@ -31112,7 +31112,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884343",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bedok Town Park"
@@ -31136,7 +31136,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884344",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tampines"
@@ -31156,7 +31156,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884345",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Simei"
@@ -31176,7 +31176,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884346",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Moon Crescent Prison"
@@ -31199,7 +31199,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884347",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Mata Ikan"
@@ -31219,7 +31219,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884348",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Changi General Purposes Anchorage"
@@ -31245,7 +31245,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884349",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Hantu"
@@ -31265,7 +31265,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884350",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kampong Sudong School"
@@ -31288,7 +31288,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884351",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "First Bukom"
@@ -31312,7 +31312,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884352",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Second Bukom"
@@ -31336,7 +31336,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884353",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Third Bukom"
@@ -31360,7 +31360,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884354",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Fourth Bukom"
@@ -31384,7 +31384,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884355",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Western Petroleum Anchorage B"
@@ -31410,7 +31410,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1884365",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Ang Mo Kio New Town"
@@ -31445,7 +31445,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884366",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Ang Mo Kio Industrial Park"
@@ -31468,7 +31468,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1884367",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bukit Panjang New Town"
@@ -31503,7 +31503,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884368",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Woodlands Industrial Park East"
@@ -31526,7 +31526,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884369",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Yishun"
@@ -31546,7 +31546,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884370",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Yishun Industrial Park"
@@ -31569,7 +31569,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884371",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Woodlands Industrial Park"
@@ -31592,7 +31592,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1884382",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bedok New Town"
@@ -31627,7 +31627,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884383",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bedok"
@@ -31650,7 +31650,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1884384",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Clementi New Town"
@@ -31673,7 +31673,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1884385",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pasir Ris New Town"
@@ -31696,7 +31696,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1884386",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Queenstown Estate"
@@ -31719,7 +31719,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884392",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Alexandra Village"
@@ -31742,7 +31742,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884393",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Ayer Chawan Industrial Estate"
@@ -31765,7 +31765,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884394",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Ayer Merbau Industrial Estate"
@@ -31788,7 +31788,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884395",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Merlimau Industrial Estate"
@@ -31811,7 +31811,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884396",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Mesemut Darat Industrial Estate"
@@ -31834,7 +31834,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884397",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Mesemut Laut Industrial Estate"
@@ -31857,7 +31857,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884398",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Meskol Industrial Estate"
@@ -31880,7 +31880,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884399",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Pesek Industrial Estate"
@@ -31903,7 +31903,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884400",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pulau Seraya Industrial Estate"
@@ -31926,7 +31926,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884401",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanglin Halt Industrial Estate"
@@ -31949,7 +31949,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1884402",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Rhu Industrial Estate"
@@ -31972,7 +31972,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1884403",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Telok Blangah New Town"
@@ -31995,7 +31995,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1884404",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Ang Mo Kio New Town"
@@ -32018,7 +32018,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1884737",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Choa Chu Kang New Town"
@@ -32053,7 +32053,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1885152",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Changi"
@@ -32087,7 +32087,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1885154",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Keppel Terminal"
@@ -32114,7 +32114,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1885155",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Marina Terminal"
@@ -32141,7 +32141,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1885156",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sir Arthur’s Bridge"
@@ -32161,7 +32161,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1885157",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sim’s Bridge"
@@ -32181,7 +32181,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1885158",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Crawford Bridge"
@@ -32201,7 +32201,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1885159",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Benjamin Sheares Bridge"
@@ -32221,7 +32221,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1885160",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Victoria Bridge"
@@ -32241,7 +32241,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1885161",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bedok Ville"
@@ -32275,7 +32275,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1885169",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Jurong Park"
@@ -32299,7 +32299,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1885170",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Jurong Sports Complex"
@@ -32322,7 +32322,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1885188",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Jurong Power Station"
@@ -32342,7 +32342,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1885189",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pasir Panjang I"
@@ -32362,7 +32362,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1885190",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bukit Pasir Panjang"
@@ -32385,7 +32385,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1885200",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Serapong Golf Course"
@@ -32409,7 +32409,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1885201",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Golf Course"
@@ -32433,7 +32433,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1885202",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Raffles Golf Course"
@@ -32457,7 +32457,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1885203",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Asia Pacific Breweries"
@@ -32480,7 +32480,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1885251",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "City"
@@ -32514,7 +32514,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1885252",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Saint Andrew’s Children Hospital"
@@ -32537,7 +32537,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1885253",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanglin Golf Course"
@@ -32561,7 +32561,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1885254",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Gleneagles Hospital"
@@ -32584,7 +32584,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1885255",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kandang Kerbau Hospital"
@@ -32607,7 +32607,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1885256",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Symphony Lake"
@@ -32631,7 +32631,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1885257",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bukit Golf Links"
@@ -32655,7 +32655,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1885258",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": [
@@ -32685,7 +32685,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1885259",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pearl’s Hill City Park"
@@ -32709,7 +32709,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1885260",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Read Bridge"
@@ -32729,7 +32729,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1885261",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Clemenceau Bridge"
@@ -32749,7 +32749,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1885262",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Coleman Bridge"
@@ -32769,7 +32769,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1885263",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "United States Embassy"
@@ -32789,7 +32789,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1885269",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bukit Rimau"
@@ -32812,7 +32812,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1885270",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Batu Rimau"
@@ -32832,7 +32832,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1885272",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Chua Chu Kang"
@@ -32866,7 +32866,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1885278",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Serangoon"
@@ -32900,7 +32900,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1885280",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Serangoon Garden"
@@ -32934,7 +32934,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1885281",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sembawang Golf Course"
@@ -32958,7 +32958,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1885282",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Orchid Golf Course"
@@ -32982,7 +32982,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1885283",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Seletar Country Club Golf Course"
@@ -33006,7 +33006,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1885285",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Singapore Aviation Academy"
@@ -33029,7 +33029,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1885286",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Changi Golf Course"
@@ -33053,7 +33053,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1885296",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Ulu Kalang"
@@ -33073,7 +33073,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1885297",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Singapore Island Golf Course"
@@ -33097,7 +33097,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1885298",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Abingdon Prison"
@@ -33120,7 +33120,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1885299",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Changi Women’s Prison"
@@ -33143,7 +33143,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1885300",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Laguna National Golf Course"
@@ -33167,7 +33167,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1885301",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Safra Golf Course"
@@ -33191,7 +33191,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1885302",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Warren Golf Course"
@@ -33215,7 +33215,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1885304",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "National University Hospital"
@@ -33238,7 +33238,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1885306",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Keppel Golf Links"
@@ -33262,7 +33262,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1885307",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Jurong Golf Course"
@@ -33286,7 +33286,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:1885550",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Faber Garden"
@@ -33309,7 +33309,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1885630",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "North Channel"
@@ -33333,7 +33333,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1888673",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "South Bukom"
@@ -33356,7 +33356,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1903708",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sembawang Terminal"
@@ -33382,7 +33382,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1903709",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "President Dock"
@@ -33408,7 +33408,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1903710",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Premier Dry Dock"
@@ -33431,7 +33431,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1903711",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bethlehem Shipyard"
@@ -33454,7 +33454,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:1903712",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kam Wak Hassan"
@@ -33489,7 +33489,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1903904",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Triton Petroleum Anchorage"
@@ -33515,7 +33515,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1903905",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tuas Explosives Lighters Anchorage"
@@ -33541,7 +33541,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1903907",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kolek Rocks"
@@ -33564,7 +33564,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1903937",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanjong Hakim"
@@ -33587,7 +33587,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1903938",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Cooper Channel"
@@ -33611,7 +33611,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:1903939",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Eastern Holding Anchorage"
@@ -33637,7 +33637,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:6355174",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": [
@@ -33679,7 +33679,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6464644",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Gallery Hotel"
@@ -33702,7 +33702,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6468319",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Meridien"
@@ -33725,7 +33725,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6468356",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Ritz Carlton"
@@ -33748,7 +33748,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6468363",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Traders"
@@ -33771,7 +33771,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6468370",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Allson"
@@ -33794,7 +33794,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6468445",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Marina Mandarin"
@@ -33817,7 +33817,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6468513",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Park Royal on Beach Road"
@@ -33840,7 +33840,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6468651",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Asia"
@@ -33863,7 +33863,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6468658",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Fullerton"
@@ -33886,7 +33886,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6468806",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sha Villa"
@@ -33909,7 +33909,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6468876",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Chinatown"
@@ -33932,7 +33932,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6468881",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Fragrance Pearl"
@@ -33955,7 +33955,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6468950",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Hotel81 Chinatown"
@@ -33978,7 +33978,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6469023",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Supreme"
@@ -34001,7 +34001,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6469032",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Quality"
@@ -34024,7 +34024,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6469111",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Grand Copthorne"
@@ -34047,7 +34047,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6469175",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Grand Copthorne Waterfront Hotel Singapore"
@@ -34070,7 +34070,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6469184",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Rendezvous Singapore"
@@ -34093,7 +34093,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6469187",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Grand Plaza Park City Hall"
@@ -34116,7 +34116,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6469267",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Orchard Parade"
@@ -34139,7 +34139,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6469334",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Relc International"
@@ -34162,7 +34162,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6469342",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Holiday Inn Atrium"
@@ -34185,7 +34185,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6469346",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Paramount"
@@ -34208,7 +34208,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6469348",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "InterContinental"
@@ -34231,7 +34231,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6469349",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Grand Central"
@@ -34254,7 +34254,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6469505",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Furama City Centre"
@@ -34277,7 +34277,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6469587",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Elizabeth"
@@ -34300,7 +34300,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6469595",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "York"
@@ -34323,7 +34323,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6469598",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Berjaya"
@@ -34346,7 +34346,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6469666",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Park Royal Kitchener Road"
@@ -34369,7 +34369,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6469667",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Royal Plaza On Scotts - A Summit Hotel"
@@ -34392,7 +34392,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6469740",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Meritus Negara"
@@ -34415,7 +34415,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6469748",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Garden"
@@ -34438,7 +34438,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6469749",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Meritus Mandarin Singapore"
@@ -34461,7 +34461,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6469808",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Hotel81 Joo Chiat"
@@ -34484,7 +34484,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6469974",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Grand Mercure Roxy"
@@ -34507,7 +34507,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6469978",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Fragrance Ruby"
@@ -34530,7 +34530,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6469982",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Raffles Plaza"
@@ -34553,7 +34553,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6469984",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Fort Canning Lodge"
@@ -34576,7 +34576,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6469985",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "River View"
@@ -34599,7 +34599,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6470058",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Furama Riverfront"
@@ -34622,7 +34622,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6470063",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tristar Inn"
@@ -34645,7 +34645,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6470065",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Royal At Newton"
@@ -34668,7 +34668,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6470143",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Fragrance Emerald"
@@ -34691,7 +34691,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6470311",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Summerview"
@@ -34714,7 +34714,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6470385",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Shangri-La"
@@ -34737,7 +34737,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6470386",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Fragrance Joo Chiat"
@@ -34760,7 +34760,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6470389",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Peninsula Excelsior"
@@ -34783,7 +34783,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6470390",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Phoenix"
@@ -34806,7 +34806,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6470394",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Albert Court"
@@ -34829,7 +34829,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6470525",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Hotel81 Bencoolen"
@@ -34852,7 +34852,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6470528",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Four Seasons"
@@ -34875,7 +34875,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6470683",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Regent"
@@ -34898,7 +34898,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6470684",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Amara"
@@ -34921,7 +34921,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6470695",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Royal At Queens"
@@ -34944,7 +34944,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6470774",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Claremont"
@@ -34967,7 +34967,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6470782",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Royal Peacock"
@@ -34990,7 +34990,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6470786",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Miramar"
@@ -35013,7 +35013,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6472416",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Robertson Quay Hotel"
@@ -35036,7 +35036,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6473474",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Le Meridien Singapore"
@@ -35059,7 +35059,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6473523",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "M Hotel Singapore"
@@ -35082,7 +35082,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6473596",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Inn at Temple Street"
@@ -35105,7 +35105,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6474834",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Golden Landmark-A Far East Hotel"
@@ -35128,7 +35128,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6475037",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Conrad Centennial Singapore"
@@ -35151,7 +35151,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6476534",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Copthorne King's Hotel Singapore"
@@ -35174,7 +35174,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6477355",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "The Elizabeth-A Far East Hotel"
@@ -35197,7 +35197,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6479599",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pan Pacific Singapore"
@@ -35220,7 +35220,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6480434",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Negara on Claymore"
@@ -35243,7 +35243,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6480982",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Carlton Hotel Singapore"
@@ -35266,7 +35266,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6481476",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": [
@@ -35295,7 +35295,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6482621",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Orchard Hotel Singapore"
@@ -35318,7 +35318,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6482825",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Raffles Hotel"
@@ -35341,7 +35341,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6483106",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Goodwood Park Hotel"
@@ -35364,7 +35364,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6484121",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Singapore Marriott Hotel"
@@ -35387,7 +35387,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6484363",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Hotel Asia"
@@ -35410,7 +35410,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6484953",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Hilton Singapore"
@@ -35433,7 +35433,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6485376",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Orchard Parade-A Far East Hotel"
@@ -35456,7 +35456,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6485658",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Albert Court-A Far East Hotel"
@@ -35479,7 +35479,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6486274",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Novotel Clarke Quay Singapore"
@@ -35502,7 +35502,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6487254",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Swissotel Merchant Court"
@@ -35525,7 +35525,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6487979",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": [
@@ -35554,7 +35554,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6488230",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": [
@@ -35583,7 +35583,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6488951",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sheraton Towers Singapore"
@@ -35606,7 +35606,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6490056",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Grand Hyatt Singapore"
@@ -35629,7 +35629,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6490258",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Shangri-La Hotel Singapore"
@@ -35652,7 +35652,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6495159",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Perak Hotel"
@@ -35675,7 +35675,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6496846",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Harbour Ville Hotel"
@@ -35698,7 +35698,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6498446",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Copthorne Orchid Hotel Singapore"
@@ -35721,7 +35721,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6499558",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Asphodel Inn Singapore"
@@ -35744,7 +35744,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6499822",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Aliwal Park Hotel"
@@ -35767,7 +35767,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6500209",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "The Scarlet Hotel"
@@ -35790,7 +35790,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6501441",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "The Oriental Singapore"
@@ -35813,7 +35813,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6501948",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Hotel 1929"
@@ -35836,7 +35836,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6502100",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": [
@@ -35865,7 +35865,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6506748",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "The Fullerton Hotel Singapore"
@@ -35888,7 +35888,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6509316",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Furama Riverfront Singapore"
@@ -35911,7 +35911,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6509327",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Oxford Hotel"
@@ -35934,7 +35934,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6510588",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Grand Plaza Park Hotel"
@@ -35957,7 +35957,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6514016",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Four Seasons Singapore"
@@ -35980,7 +35980,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6515520",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Furama City Center Hotel"
@@ -36003,7 +36003,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6516550",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Paramount Hotel"
@@ -36026,7 +36026,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6518010",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Peninsula Excelsior Hotel"
@@ -36049,7 +36049,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6518069",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "The Regent Singapore"
@@ -36072,7 +36072,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6518431",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Parkroyal Residences"
@@ -36095,7 +36095,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6527583",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Somerset Grand Cairnhill"
@@ -36118,7 +36118,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6527644",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Somerset Compass"
@@ -36141,7 +36141,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6528055",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Somerset Liang Court Singapore"
@@ -36164,7 +36164,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6528191",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Ascott Singapore Raffles Place"
@@ -36187,7 +36187,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6528287",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Somerset Bencoolen"
@@ -36210,7 +36210,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6528371",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Somerset Orchard  Singapore"
@@ -36233,7 +36233,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6530999",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Fraser Suites Singapore"
@@ -36256,7 +36256,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6531306",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Fraser Place Robertson Walk"
@@ -36279,7 +36279,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6615208",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "BLK 658D"
@@ -36300,7 +36300,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6615306",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "BLK658D"
@@ -36321,7 +36321,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6620415",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Yio Chu Kang MRT Station"
@@ -36345,7 +36345,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6620416",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Seng Kang MRT Station"
@@ -36369,7 +36369,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6620417",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Buangkok MRT Station"
@@ -36393,7 +36393,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6620419",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Compass Point"
@@ -36416,7 +36416,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6620420",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Fernvale LRT Station"
@@ -36440,7 +36440,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6620421",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Fernvale Primary School"
@@ -36463,7 +36463,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6620423",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Thanggam LRT Station"
@@ -36487,7 +36487,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6620424",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Layar LRT Station"
@@ -36511,7 +36511,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6620425",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Temasek Polytechnic"
@@ -36534,7 +36534,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6620430",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Hougang MRT Station"
@@ -36558,7 +36558,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6620431",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kovan MRT Station"
@@ -36582,7 +36582,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6620433",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Serangoon MRT Station"
@@ -36606,7 +36606,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6620434",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Potong Pasir MRT Station"
@@ -36630,7 +36630,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6620435",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Boon Keng MRT Station"
@@ -36654,7 +36654,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6620436",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Farrer Park MRT Station"
@@ -36678,7 +36678,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6620437",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Little India MRT Station"
@@ -36702,7 +36702,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6620438",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Dhoby Ghaut MRT Station"
@@ -36726,7 +36726,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6620439",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Clarke Quay MRT Station"
@@ -36750,7 +36750,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6620440",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Chinatown MRT Station"
@@ -36774,7 +36774,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6620441",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Outram Park MRT Station"
@@ -36798,7 +36798,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6620442",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Harbour Front MRT Station"
@@ -36822,7 +36822,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:6690793",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Blk 822 Jurong West Street 81"
@@ -36857,7 +36857,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6690951",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Suntec Singapore International Convention and Exhibition Centre"
@@ -36877,7 +36877,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:6695743",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Johor"
@@ -36912,7 +36912,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6940488",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": [
@@ -36939,7 +36939,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6940489",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "The Central"
@@ -36963,7 +36963,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6940490",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Funan DigitaLife Mall"
@@ -36987,7 +36987,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:6942030",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Night Safari"
@@ -37022,7 +37022,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6942285",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Central Catchment Natural Reserve"
@@ -37045,7 +37045,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6942288",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Chinatown Singapore"
@@ -37068,7 +37068,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6951474",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "City Hall (Singapore)"
@@ -37091,7 +37091,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6951475",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Empress Place Building"
@@ -37111,7 +37111,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6951476",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Esplanade - Theatres on the Bay"
@@ -37131,7 +37131,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6951477",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Fort Canning Park"
@@ -37155,7 +37155,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6951478",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Merlion"
@@ -37178,7 +37178,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6951479",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Nationalmuseum Singapur"
@@ -37202,7 +37202,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6951480",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "One Raffles Quay"
@@ -37222,7 +37222,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6951481",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "OUB Centre"
@@ -37242,7 +37242,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:6956032",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Paya Lebar Cresent"
@@ -37262,7 +37262,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:7281987",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Novena"
@@ -37297,7 +37297,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:7289731",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Eunos"
@@ -37332,7 +37332,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:7289733",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Jurong Island"
@@ -37355,7 +37355,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:7289737",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bugis"
@@ -37390,7 +37390,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:7289739",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Admiralty"
@@ -37413,7 +37413,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:7289740",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Orchard"
@@ -37448,7 +37448,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:7289742",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "International Business Park"
@@ -37472,7 +37472,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:7289743",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bukit Timah"
@@ -37507,7 +37507,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:7289745",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Lavender"
@@ -37530,7 +37530,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:7289746",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Newton"
@@ -37565,7 +37565,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:7289749",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Raffles Place"
@@ -37588,7 +37588,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:7289760",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sengkang New Town"
@@ -37623,7 +37623,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:locality:7289766",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "HarbourFront"
@@ -37658,7 +37658,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:7289770",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Delta Road"
@@ -37681,7 +37681,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:7289774",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Lower Delta Road"
@@ -37704,7 +37704,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:region:7535954",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Central Singapore Community Development Council"
@@ -37728,7 +37728,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:region:7535955",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "North East Community Development Region"
@@ -37752,7 +37752,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:region:7535956",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "South East Community Development Council"
@@ -37776,7 +37776,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:region:7535957",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "South West Community Development Council"
@@ -37800,7 +37800,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:region:7535958",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "North West Community Development Council"
@@ -37824,7 +37824,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:8354422",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Marina Bay"
@@ -37847,7 +37847,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:8378724",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kranji Racecourse"
@@ -37871,7 +37871,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:8394304",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Marina Bay Street Circuit"
@@ -37895,7 +37895,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:8436367",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Universal Studios Singapore"
@@ -37918,7 +37918,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9645379",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Singapore Naval Base (historical)"
@@ -37942,7 +37942,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9853641",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tanah Merah Port"
@@ -37969,7 +37969,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9882671",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Studio M Hotel"
@@ -37992,7 +37992,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9882674",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Parkroyal On Beach Road"
@@ -38015,7 +38015,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9882675",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Parkroyal On Kitchener Road"
@@ -38038,7 +38038,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9882676",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": [
@@ -38067,7 +38067,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9882677",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Marina Bay Sands"
@@ -38090,7 +38090,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9882678",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Holiday Inn Singapore Orchard"
@@ -38113,7 +38113,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9882679",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Fullerton Bay"
@@ -38136,7 +38136,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9882680",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Ywca Fort Canning Lodge"
@@ -38159,7 +38159,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9882681",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Hotel Grand Pacific"
@@ -38182,7 +38182,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9882682",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "BIG"
@@ -38205,7 +38205,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9882683",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Soluxe Inn"
@@ -38228,7 +38228,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9882684",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Dorsett"
@@ -38251,7 +38251,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9882685",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Ramada"
@@ -38274,7 +38274,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9882686",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kam Leng"
@@ -38297,7 +38297,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9882687",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Cultural"
@@ -38320,7 +38320,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9882688",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tresor Tavern Hotel"
@@ -38343,7 +38343,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9882689",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Marrison Hotel Desker Road"
@@ -38366,7 +38366,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9882690",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Changi Cove"
@@ -38389,7 +38389,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9882691",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Hotel Clover Hongkong Street"
@@ -38412,7 +38412,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9882692",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "The Westin Singapore"
@@ -38435,7 +38435,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9882693",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Carlton City"
@@ -38458,7 +38458,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9886443",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Grand Soluxe Angkor Palace Resort & Spa"
@@ -38481,7 +38481,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949634",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Hotel81 - Opera"
@@ -38504,7 +38504,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949635",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Inter-Continental (Shophouse)"
@@ -38527,7 +38527,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949636",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Changi Village"
@@ -38550,7 +38550,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949637",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Concorde"
@@ -38573,7 +38573,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949638",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Capella Singapore"
@@ -38596,7 +38596,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949639",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Hotel 81 Sakura"
@@ -38619,7 +38619,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949640",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Fragrance Hotel Riverside"
@@ -38642,7 +38642,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949641",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Fragrance Hotel-Oasis"
@@ -38665,7 +38665,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949642",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Park Regis Singapore"
@@ -38688,7 +38688,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949643",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Innotel"
@@ -38711,7 +38711,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949644",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Wanderlust"
@@ -38734,7 +38734,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949645",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Hotel 81 Gold"
@@ -38757,7 +38757,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949646",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "81 - Rochor"
@@ -38780,7 +38780,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949647",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "The Saff"
@@ -38803,7 +38803,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949648",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "81 Bugis"
@@ -38826,7 +38826,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949649",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "The Aspinals Hotel"
@@ -38849,7 +38849,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949650",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Hotel Re!"
@@ -38872,7 +38872,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949651",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Value Thomson"
@@ -38895,7 +38895,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949652",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "The Quincy"
@@ -38918,7 +38918,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949653",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Hotel 81 Geylang"
@@ -38941,7 +38941,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949654",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Fragrance Hotel - Sapphire"
@@ -38964,7 +38964,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949655",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Ibis Singapore Novena"
@@ -38987,7 +38987,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949656",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Grand Park Orchard Hotel"
@@ -39010,7 +39010,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949657",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "New Majestic"
@@ -39033,7 +39033,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949658",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Fragrance - Balestier"
@@ -39056,7 +39056,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949659",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Fragrance - Imperial"
@@ -39079,7 +39079,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949660",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Porcelain Hotel"
@@ -39102,7 +39102,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949661",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "81 - Star"
@@ -39125,7 +39125,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949662",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Fairmont Singapore"
@@ -39148,7 +39148,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949663",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Victoria Hotel"
@@ -39171,7 +39171,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949664",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Hotel81 - Palace"
@@ -39194,7 +39194,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949665",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Royal Queens Hotel"
@@ -39217,7 +39217,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949666",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Moevenpick Heritage Hotel Sentosa"
@@ -39240,7 +39240,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949667",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Fragrance - Rose"
@@ -39263,7 +39263,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949668",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "81 Joo Chiat"
@@ -39286,7 +39286,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949669",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Rider's Lodge Singapore"
@@ -39309,7 +39309,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949670",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Holiday Inn Parkview"
@@ -39332,7 +39332,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949671",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Holiday Inn Express Singapore Clarke Quay"
@@ -39355,7 +39355,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949672",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Value Balestier Hotel"
@@ -39378,7 +39378,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949673",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Hangout@Mt.Emily Hotel"
@@ -39401,7 +39401,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949674",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Metropolitan Y"
@@ -39424,7 +39424,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949675",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Summer View Hotel"
@@ -39447,7 +39447,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949676",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Oasia Hotel"
@@ -39470,7 +39470,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949678",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Ymca International"
@@ -39493,7 +39493,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949679",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "New Park"
@@ -39516,7 +39516,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949680",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Hotel 81 Classic"
@@ -39539,7 +39539,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949681",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Hotel 81 - Selegie"
@@ -39562,7 +39562,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949682",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Meritus Mandarin Orchad Singapore"
@@ -39585,7 +39585,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949683",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "81 Orchid"
@@ -39608,7 +39608,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949684",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "81 Tristar"
@@ -39631,7 +39631,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949685",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Ambassador"
@@ -39654,7 +39654,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949686",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Hotel 81 Elegance"
@@ -39677,7 +39677,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949687",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Meritius Orchard"
@@ -39700,7 +39700,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949688",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Hotel 81 Bencoolen"
@@ -39723,7 +39723,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949689",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Holiday Inn Orchard City Centre"
@@ -39746,7 +39746,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949690",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Moon @ 23 Dickson"
@@ -39769,7 +39769,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949691",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Citadines Mount Sophia Singapore"
@@ -39792,7 +39792,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949692",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "The Ritz-Carlton Millenia Singapore"
@@ -39815,7 +39815,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949693",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "81 Palace"
@@ -39838,7 +39838,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949694",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Hotel 81 Kovan"
@@ -39861,7 +39861,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949695",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Value Hotel Nice"
@@ -39884,7 +39884,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949696",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Cultural Hotel Singapor Pte Ltd"
@@ -39907,7 +39907,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949697",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Wangz Hotel"
@@ -39930,7 +39930,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949698",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Hotel81 - Selegie"
@@ -39953,7 +39953,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949699",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "St. Regis Hotel Singapore"
@@ -39976,7 +39976,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949700",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Fragrance - Selegie"
@@ -39999,7 +39999,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949701",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Fragrance Hostel"
@@ -40022,7 +40022,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949702",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Fragrance Hotel Bugis"
@@ -40045,7 +40045,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949703",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Hotel 81 Lucky"
@@ -40068,7 +40068,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949704",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Naumi Hotel"
@@ -40091,7 +40091,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949705",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Crown At Orchard"
@@ -40114,7 +40114,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949706",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "V Hotel Lavender"
@@ -40137,7 +40137,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949707",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Le Peranakan"
@@ -40160,7 +40160,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949708",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Rendezvous Grand Hotel Singapore"
@@ -40183,7 +40183,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949709",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Fragrance Crystal"
@@ -40206,7 +40206,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949710",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Hotel 81 Princess"
@@ -40229,7 +40229,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949711",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Mandarin Oriental"
@@ -40252,7 +40252,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949712",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Fragrance - Royal"
@@ -40275,7 +40275,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949713",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "The Sentosa"
@@ -40298,7 +40298,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949714",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Siloso Beach Resort"
@@ -40321,7 +40321,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949715",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Festive Hotel"
@@ -40344,7 +40344,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949716",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Equarius"
@@ -40367,7 +40367,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949717",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Shangri-La Rasa Sentosa Resort"
@@ -40390,7 +40390,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949718",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Treasure Resort"
@@ -40413,7 +40413,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9949719",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Amara Sanctuary Resort Sentosa"
@@ -40436,7 +40436,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9957773",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Fragrance Hotel Selegie"
@@ -40459,7 +40459,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9957774",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Hangout Mt Emily Hotel"
@@ -40482,7 +40482,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9957775",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Quality Hotel Marlow"
@@ -40505,7 +40505,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9957776",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Link Hotel Singapore"
@@ -40528,7 +40528,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9957777",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bayview Superior"
@@ -40551,7 +40551,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9957778",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Village Hotel Bugis Prev Landmark Village"
@@ -40574,7 +40574,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9957779",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Crowne Plaza Changi Airport Hotel"
@@ -40597,7 +40597,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9957780",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Movenpick Heritage Hotel Sentosa"
@@ -40620,7 +40620,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9957781",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Carlton Singapore Superior"
@@ -40643,7 +40643,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9957782",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Singapore Resort And Spa Sentosa"
@@ -40666,7 +40666,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9957783",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Mandarin Orchard Deluxe"
@@ -40689,7 +40689,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9957784",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Singapore Resort And Spa Sentosa Deluxe"
@@ -40712,7 +40712,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9957951",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "V Hotel Lavender Superior Twin"
@@ -40735,7 +40735,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9957965",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "The Duxton Hotel Prev Berjaya Hotel Singapore"
@@ -40758,7 +40758,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9957996",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "V Hotel Lavender Superior Double"
@@ -40781,7 +40781,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9957997",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pan Pacific Singapore Deluxe"
@@ -40804,7 +40804,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9957998",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Park Hotel Clarke Quay Superior"
@@ -40827,7 +40827,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9958017",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Days Hotel"
@@ -40850,7 +40850,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9958018",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Ramada Singapore At Zhongshan Park"
@@ -40873,7 +40873,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9958305",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Marina Mandarin Deluxe"
@@ -40896,7 +40896,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9958402",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Mandarin Oriental Premier Harbour"
@@ -40919,7 +40919,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9958495",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Days Singapore At Zhongshan Park"
@@ -40942,7 +40942,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9958766",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pan Pacific Orchard Executive"
@@ -40965,7 +40965,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9963639",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "81 Opera"
@@ -40988,7 +40988,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9963640",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "The Staff Hotel"
@@ -41011,7 +41011,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9970044",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Capri By Fraser"
@@ -41034,7 +41034,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9970153",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "W Sentosa Cove"
@@ -41057,7 +41057,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9970291",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Fragrance Elegance"
@@ -41080,7 +41080,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9970697",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Raffles Courtyard"
@@ -41103,7 +41103,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9970699",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Hotel81 Dickson"
@@ -41126,7 +41126,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9970700",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "East Village"
@@ -41149,7 +41149,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9970704",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Ibis On Bencoolen"
@@ -41172,7 +41172,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9970707",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Singapore Recreation Club"
@@ -41195,7 +41195,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:9970709",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Hotel 81 Osaka"
@@ -41218,7 +41218,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10054956",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pan Pacific Orchard (Pacific Club)"
@@ -41241,7 +41241,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10055052",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Royal Plaza On Scotts (Royal Club Prem)"
@@ -41264,7 +41264,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10056711",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Park Regis Singapore (Park Twin)"
@@ -41287,7 +41287,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10056727",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "St Regis (Lady Astor)"
@@ -41310,7 +41310,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10056779",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "St Regis (Caroline Astor Suite)"
@@ -41333,7 +41333,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10063469",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "The Sultan"
@@ -41356,7 +41356,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10063470",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Amoy"
@@ -41379,7 +41379,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10063472",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Santa Grand Hotel Bugis"
@@ -41402,7 +41402,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10063474",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Hotel Nostalgia"
@@ -41425,7 +41425,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10063475",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Re"
@@ -41448,7 +41448,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10063477",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Venue Hotel The Lily"
@@ -41471,7 +41471,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10063478",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Hotel Grand Chancellor"
@@ -41494,7 +41494,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10063480",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "The Singapore Resort & Spa Sen"
@@ -41517,7 +41517,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10063482",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Hotel Michael"
@@ -41540,7 +41540,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10063484",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Hard Rock Singapore"
@@ -41563,7 +41563,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10100275",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Jen Orchardgateway Singapore"
@@ -41586,7 +41586,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10100276",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Quarters Hostel"
@@ -41609,7 +41609,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10102148",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Rucksack Inn Temple Street"
@@ -41632,7 +41632,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10102151",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Royal Hostel Singapore"
@@ -41655,7 +41655,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10102155",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Parc Sovereign Hotel Tyrwhitt"
@@ -41678,7 +41678,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10102162",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Clover The Arts"
@@ -41701,7 +41701,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10102170",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Clover 33 Jalan Sultan"
@@ -41724,7 +41724,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10102174",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Arton Hotel"
@@ -41747,7 +41747,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10102176",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Aqueen Jalan Besar"
@@ -41770,7 +41770,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10102180",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "5Footway.Inn Project Chinatown 2"
@@ -41793,7 +41793,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10102184",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "5Footway.Inn Project Chinatown 1"
@@ -41816,7 +41816,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10102187",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "5Footway.Inn Project Bugis"
@@ -41839,7 +41839,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10103894",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Village Residence Clarke Quay"
@@ -41862,7 +41862,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10105269",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "St Regis (Grand Deluxe)"
@@ -41885,7 +41885,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10105277",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Marina Bay Sands (Grand Club)"
@@ -41908,7 +41908,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10106220",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Village Residence Robertson Qu"
@@ -41931,7 +41931,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10106223",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Swissotel Stamford (Classic Harbour Vw)"
@@ -41954,7 +41954,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10106228",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Marina Mandarin (Executive Deluxe)"
@@ -41977,7 +41977,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10106235",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Shangri-La (Tower Wing Deluxe)"
@@ -42000,7 +42000,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10106237",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Shangri-La (Garden Wing Deluxe)"
@@ -42023,7 +42023,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10106257",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Shangri-La Rasa Sentosa (Sup Hill View)"
@@ -42046,7 +42046,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10106272",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Mandarin Oriental (Premier Ocean)"
@@ -42069,7 +42069,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10106308",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Shangri-La (Valley Wing Deluxe)"
@@ -42092,7 +42092,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10106313",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Grand Hyatt (Grand Deluxe)"
@@ -42115,7 +42115,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10106315",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "St Regis (Executive Deluxe)"
@@ -42138,7 +42138,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10106318",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Raffles (Palmcourt)"
@@ -42161,7 +42161,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10106320",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Shangri-La Rasa Sentosa (Dlx Sea View)"
@@ -42184,7 +42184,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10106322",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Shangri-La (Horizon Club Premier)"
@@ -42207,7 +42207,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10108189",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sofitel So Singapore"
@@ -42230,7 +42230,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10108190",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Lanson Place Winsland Residences"
@@ -42253,7 +42253,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10108191",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "One Farrer Hotel & Spa"
@@ -42276,7 +42276,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10108192",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Duxton (Deluxe Double)"
@@ -42299,7 +42299,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10108193",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "The Metropolitan Y Hotel"
@@ -42322,7 +42322,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10108194",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Holiday Inn Express Singapore Orchard Road"
@@ -42345,7 +42345,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10108195",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Village Hotel Katong"
@@ -42368,7 +42368,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10108196",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Parc Sovereign Hotel Tyrwhit"
@@ -42391,7 +42391,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10108197",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "The Duxton (Previously Berjaya"
@@ -42414,7 +42414,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10108198",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "The Seacare Hotel"
@@ -42437,7 +42437,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10108199",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Parc Sovereign Albert St"
@@ -42460,7 +42460,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10108200",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Hotel81 Tristar"
@@ -42483,7 +42483,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10108201",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Fragrance Ocean View"
@@ -42506,7 +42506,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10108202",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Fragrance Waterfront"
@@ -42529,7 +42529,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10108203",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Hotel81 Premier Star"
@@ -42552,7 +42552,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10108204",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Grand U"
@@ -42575,7 +42575,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10109607",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Woke Home Capsule Hostel"
@@ -42598,7 +42598,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10109608",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Vip Hotel"
@@ -42621,7 +42621,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10109609",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Vintage Inn Singapore"
@@ -42644,7 +42644,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10109611",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "The Residence At Singapore Recreation Club"
@@ -42667,7 +42667,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10109612",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "The Pod Boutique Capsule Hotel"
@@ -42690,7 +42690,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10109613",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "The Forest By Wangz"
@@ -42713,7 +42713,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10109614",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Rucksack Innhong Kong Street"
@@ -42736,7 +42736,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10109616",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Plush Pods"
@@ -42759,7 +42759,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10109622",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Park Avenue Rochester Hotel"
@@ -42782,7 +42782,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10109624",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Park Avenue Changi Hotel"
@@ -42805,7 +42805,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10109626",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Nuve"
@@ -42828,7 +42828,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10109628",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "New Happy Hotel"
@@ -42851,7 +42851,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10109631",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Lofi Inn Hamilton"
@@ -42874,7 +42874,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10109634",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Le Grove Serviced Apartments"
@@ -42897,7 +42897,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10109636",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Ibackpacker Kallang"
@@ -42920,7 +42920,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10109638",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "G4 Station Backpackers' Hostel"
@@ -42943,7 +42943,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10109640",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Four Chain View Hotel"
@@ -42966,7 +42966,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10109641",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "D'kranji Farm Resort"
@@ -42989,7 +42989,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10109643",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Darlene Hotel"
@@ -43012,7 +43012,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10109645",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Checkers Backpackers Inn"
@@ -43035,7 +43035,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10109647",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Buncradius Clarke Quay"
@@ -43058,7 +43058,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10109648",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Blissful Loft"
@@ -43081,7 +43081,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10109649",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bliss Hotel Singapore"
@@ -43104,7 +43104,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10109650",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "One 15 Marina Club"
@@ -43127,7 +43127,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10109652",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Blanc Inn"
@@ -43150,7 +43150,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10109659",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Adler Hostel"
@@ -43173,7 +43173,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10109661",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "5Footwayinn Project Boat Quay"
@@ -43196,7 +43196,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10110348",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Tresor Tavern Hostel"
@@ -43219,7 +43219,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10110349",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Madras Eminence"
@@ -43242,7 +43242,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10111554",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sandpiper Hotel"
@@ -43265,7 +43265,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10111644",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Fortuna Singapore"
@@ -43288,7 +43288,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10112165",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Abc Premium Hostel"
@@ -43311,7 +43311,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10112166",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Madras Hotel Tekka"
@@ -43334,7 +43334,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10112961",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Park 22"
@@ -43357,7 +43357,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10112962",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Kawan Hostel"
@@ -43380,7 +43380,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10113191",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Amaris Hotel Bugis"
@@ -43403,7 +43403,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10113616",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Capsules The Little Red Dot"
@@ -43426,7 +43426,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10114424",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Santa Grand Hotel East Coast"
@@ -43449,7 +43449,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10115513",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Parkroyal On Pickering"
@@ -43472,7 +43472,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10115744",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Beach Villa Resort World Sentosa"
@@ -43495,7 +43495,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10117851",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Capri By Fraser Changi City"
@@ -43518,7 +43518,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10117853",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Santa Grand Lai Chun Yuen"
@@ -43541,7 +43541,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10117856",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Orchid Country Club"
@@ -43564,7 +43564,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10117859",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Goldkist Beach Resort"
@@ -43587,7 +43587,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10117861",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bunc Radius Hostel"
@@ -43610,7 +43610,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10117864",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Aqueen Hotel Lavender"
@@ -43633,7 +43633,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10117865",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Aqueen Hotel Balestier"
@@ -43656,7 +43656,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10118741",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Hotel 101"
@@ -43679,7 +43679,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10118742",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Grand C"
@@ -43702,7 +43702,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10120311",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Riverside Village Residences"
@@ -43725,7 +43725,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10120312",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Hotel 81 Hollywood"
@@ -43748,7 +43748,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10120313",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Hotel 81 Heritage"
@@ -43771,7 +43771,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10120314",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Hotel 81 Cosy"
@@ -43794,7 +43794,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10120315",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Far East Plaza Apartment"
@@ -43817,7 +43817,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10120316",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Central Square Village Residences"
@@ -43840,7 +43840,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10120317",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Society Hotel"
@@ -43863,7 +43863,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10120735",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Best Western Jayleen 1918"
@@ -43886,7 +43886,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10123388",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Naumi Liora"
@@ -43909,7 +43909,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10123389",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Santa Grand Hotel West Coast"
@@ -43932,7 +43932,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10123390",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Santa Grand Hotel Chinatown"
@@ -43955,7 +43955,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10123391",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Le Hotel Carpenter"
@@ -43978,7 +43978,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10124586",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "The Singapore Resort And Spa Sentosa Managed By Accor"
@@ -44001,7 +44001,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10124588",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Village Hotel Albert Court"
@@ -44024,7 +44024,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10124592",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Hotel Clover North Bridge"
@@ -44047,7 +44047,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10124595",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Marrisson Hotel Beach Road"
@@ -44070,7 +44070,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10124599",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Hotel81 Bugis"
@@ -44093,7 +44093,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10124601",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Amaris Hotel By Santika Bugr"
@@ -44116,7 +44116,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10124604",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Hotel81 Rochor"
@@ -44139,7 +44139,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10124606",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Hotel81 Elegance"
@@ -44162,7 +44162,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10124607",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Hotel81 Princess"
@@ -44185,7 +44185,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10124609",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Fragrance Sunflower"
@@ -44208,7 +44208,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10124611",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Hotel81 Orchid"
@@ -44231,7 +44231,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10124613",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Hotel81 Geylang"
@@ -44254,7 +44254,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10125051",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Capri By Fraser Hotel Residenc"
@@ -44277,7 +44277,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10125115",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Ritz Carlton Millenia (Deluxe Marina)"
@@ -44300,7 +44300,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10125445",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Fragrance Hotel Rose"
@@ -44323,7 +44323,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10125522",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Fragrance Hotel Sun Flower"
@@ -44346,7 +44346,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10125592",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Orchard Scotts Residences"
@@ -44369,7 +44369,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10126540",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Moevenpick Heritage (Heritage Premium)"
@@ -44392,7 +44392,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10126541",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Park Royal On Pickering"
@@ -44415,7 +44415,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10126800",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Hotel 81 Star Premier"
@@ -44438,7 +44438,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10127142",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "The Fullerton Bay Hotel"
@@ -44461,7 +44461,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10127143",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Shangri-La's Rasa Sentosa Resort"
@@ -44484,7 +44484,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10127838",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Ymca International House"
@@ -44507,7 +44507,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10128847",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pan Pacific Singapore (Deluxe Balcony)"
@@ -44530,7 +44530,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10128872",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pan Pacific Singapore (Harbour Studio)"
@@ -44553,7 +44553,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10128875",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pan Pacific Singapore (Panoramic)"
@@ -44576,7 +44576,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10128908",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pan Pacific Orchard(Pacific Club Studio)"
@@ -44599,7 +44599,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10129010",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Fraser Suites River Valley"
@@ -44622,7 +44622,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10129218",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Hotel 81 Dickson"
@@ -44645,7 +44645,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10129219",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Hotel 81 Chinatown"
@@ -44668,7 +44668,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10129220",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Metropolitan Ymca"
@@ -44691,7 +44691,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10129222",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Arianna"
@@ -44714,7 +44714,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10129788",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Santa Grand Little India"
@@ -44737,7 +44737,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10129789",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Santa Grand Aljunied"
@@ -44760,7 +44760,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10129790",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Regency House"
@@ -44783,7 +44783,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10129791",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Orchard Parksuites"
@@ -44806,7 +44806,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10171209",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "V Hotel Lavender (Family Room)"
@@ -44829,7 +44829,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:10171214",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Sentosa"
@@ -44852,7 +44852,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10171291",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Parkroyal On Pickering (Orchid Club)"
@@ -44875,7 +44875,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10174039",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Studio M Studio Loft"
@@ -44898,7 +44898,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10174040",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Studio M Premier Loft"
@@ -44921,7 +44921,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10174070",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Carlton City Carlton Club"
@@ -44944,7 +44944,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10174139",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Marina Mandarin Exec Dlx Marina Bay"
@@ -44967,7 +44967,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10174272",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Shangri-LaGarden Wing Deluxe Pool View"
@@ -44990,7 +44990,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10174287",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Swissotel Stamford Classic Highrise"
@@ -45013,7 +45013,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10174288",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Swissotel Stamford Classic Hbr Hi-Rise"
@@ -45036,7 +45036,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10174290",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "V Bencoolen"
@@ -45059,7 +45059,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10177010",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Beach Villas"
@@ -45082,7 +45082,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10177268",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Shangri-La Rasa Sentosa Pan Sea View"
@@ -45105,7 +45105,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10177332",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bayview Family"
@@ -45128,7 +45128,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10177483",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "W Sentosa Cove Wonderful"
@@ -45151,7 +45151,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10227907",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Village Hotel Albert Court By Far East Hospitality"
@@ -45174,7 +45174,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10227908",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Shangri-La'S Rasa Sentosa Resort & Spa"
@@ -45197,7 +45197,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10227909",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "The Singapore Resort & Spa Sentosa By Accor"
@@ -45220,7 +45220,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10227910",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Village Hotel Bugis By Far East Hospitality"
@@ -45243,7 +45243,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10227911",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Regent Singapore - A Four Seasons Hotel"
@@ -45266,7 +45266,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10227912",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Hotel 34"
@@ -45289,7 +45289,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10227967",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Village Residence Clark Quay"
@@ -45312,7 +45312,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10227968",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Village Residence Robertson Quay"
@@ -45335,7 +45335,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10228113",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Hotel Clover 769 North Bridge Road"
@@ -45358,7 +45358,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:neighbourhood:10228323",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Central Water Catchment"
@@ -45381,7 +45381,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10228324",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "MacRitchie Nature Trail"
@@ -45401,7 +45401,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10229109",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Hotel Clover 5 Hongkong Street"
@@ -45424,7 +45424,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10229176",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Pan Pacific Serviced Suites Beach Road"
@@ -45447,7 +45447,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10232320",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "The Pod - Boutique Capsules"
@@ -45470,7 +45470,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10232321",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Rucksack Inn@Hong Kong Street"
@@ -45493,7 +45493,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10232322",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Adonis Hotel"
@@ -45516,7 +45516,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10233114",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bunc@Radius Clarke Quay"
@@ -45539,7 +45539,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10235770",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Marrison Hotel At Desker"
@@ -45562,7 +45562,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10235771",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Resorts World Sentosa - Beach Villa"
@@ -45585,7 +45585,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10243393",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Shangri La S Rasa Sentosa Resort and Spa"
@@ -45608,7 +45608,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10243394",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Citadines Mt Sophia"
@@ -45631,7 +45631,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10243395",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "The Quincy Hotel By Far East Hospitality"
@@ -45654,7 +45654,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10243396",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Fragrance Hotel Royal"
@@ -45677,7 +45677,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10243397",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Parc Sovereign Hotel – Albert Street"
@@ -45700,7 +45700,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10243398",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Oasia Hotel Singapore By Far East Hospitality"
@@ -45723,7 +45723,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10243399",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Society Backpackers Hotel"
@@ -45746,7 +45746,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10243400",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Hotel 81 Balestier"
@@ -45769,7 +45769,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10243401",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Re!"
@@ -45792,7 +45792,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10244613",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Hostel Bunc@Radius Little Indi"
@@ -45815,7 +45815,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10244708",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Holiday Inn Express Clarke Qua"
@@ -45838,7 +45838,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10244721",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Hotel Grand Imperial"
@@ -45861,7 +45861,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10244736",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Marrison Hotel Beach Road"
@@ -45884,7 +45884,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10273325",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Genting Hotel Jurong"
@@ -45907,7 +45907,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10278365",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Buncradius Hostel Clarke Quay"
@@ -45930,7 +45930,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10283427",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Fragrance Hotel Royal Non Refundable Room"
@@ -45953,7 +45953,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10283428",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Fragrance Hotel Riverside Non Refundable Room"
@@ -45976,7 +45976,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10283430",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Parc Sovereign Tyrwhitt Hotel Non Refundable Room"
@@ -45999,7 +45999,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10283431",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Village Hotel Albert Court Non Refundable Room"
@@ -46022,7 +46022,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10283445",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Oasia Hotel Singapore Non Refundable Room"
@@ -46045,7 +46045,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10283517",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Link Hotel Singapore Non Refundable Room"
@@ -46068,7 +46068,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10285297",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Shangri La Apartments and Reside"
@@ -46091,7 +46091,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10289724",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Wangz Boutique"
@@ -46114,7 +46114,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10289725",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "The St Regis Singapore"
@@ -46137,7 +46137,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10289726",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "The Regent Singapore A Four Seasons Hotel"
@@ -46160,7 +46160,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10289727",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "The Chancellor Hostel"
@@ -46183,7 +46183,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10289729",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Siloso Beach Resort Sentosa"
@@ -46206,7 +46206,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10289730",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Royals At Queens"
@@ -46229,7 +46229,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10289731",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Rasa Sentosa Resort Singapore By Shangri La"
@@ -46252,7 +46252,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10289732",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Hotel Grand Central Limited"
@@ -46275,7 +46275,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10289733",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Happy Hotel Spring"
@@ -46298,7 +46298,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10289734",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Crown Prince"
@@ -46321,7 +46321,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10289735",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Cityhub Hotel"
@@ -46344,7 +46344,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10289736",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Backpackers Inn Chinatown"
@@ -46367,7 +46367,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10290360",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Nirwana Beach Club"
@@ -46390,7 +46390,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10302510",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Park Hotel Alexandra"
@@ -46413,7 +46413,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10302957",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Hotel Jen Orchardgateway Singa"
@@ -46436,7 +46436,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10303206",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "One Farrer Hotel and Spa"
@@ -46459,7 +46459,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10303308",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Far East Plaza Residences"
@@ -46482,7 +46482,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10303401",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Jen Orchard Gateway"
@@ -46505,7 +46505,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10303490",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Copthorne King S Hotel Non Refundable Room"
@@ -46528,7 +46528,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10303492",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "The Scarlet Hotel Non Refundable Room"
@@ -46551,7 +46551,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10303493",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "The Quincy Hotel Non Refundable Room"
@@ -46574,7 +46574,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10303510",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "The Duxton Hotel Non Refundable Room"
@@ -46597,7 +46597,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10303536",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "The Elizabeth Hotel Singapore Non Refundable Room"
@@ -46620,7 +46620,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10303537",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "The Westin Singapore Non Refundable Room"
@@ -46643,7 +46643,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10303567",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Amara Singapore Hotel Non Refundable Room"
@@ -46666,7 +46666,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10303569",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Rendezvous Hotel Singapore Non Refundable Room"
@@ -46689,7 +46689,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10303575",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Hilton Singapore Non Refundable Room"
@@ -46712,7 +46712,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10303587",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Village Hotel Katong Non Refundable Room"
@@ -46735,7 +46735,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10303590",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Village Hotel Bugis Non Refundable Room"
@@ -46758,7 +46758,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10303595",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bayview Hotel Singapore Non Refundable Room"
@@ -46781,7 +46781,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10330384",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Chang Ziang Hotel"
@@ -46804,7 +46804,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10340618",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "The Sentosa Resort and Spa Beaufort"
@@ -46827,7 +46827,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10340619",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Re!"
@@ -46850,7 +46850,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10340621",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Equarius Beach Villa"
@@ -46873,7 +46873,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10343726",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Raintr33 Hotel Singapore"
@@ -46896,7 +46896,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:10343728",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Bunc@Radius Hostel Clarke Quay"
@@ -46919,7 +46919,7 @@
   {
     "_index": "pelias",
     "_id": "geonames:venue:11001543",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "Beach Hotel"


### PR DESCRIPTION
As of `pelias-config@4.8.0`, the default Elasticsearch type name is now `_doc`, which is the value compatible with Elasticsearch 7.

This PR updates the Geonames functional tests to expect that new value.

Connects https://github.com/pelias/config/pull/122
Connects https://github.com/pelias/pelias/issues/831
Fixes https://github.com/pelias/geonames/issues/378