### PR TITLE
fix(download): Make download directory before downloading

### DIFF
--- a/lib/tasks/download.js
+++ b/lib/tasks/download.js
@@ -1,6 +1,6 @@
-'use strict';
-
 const child_process = require('child_process');
+const fs = require('fs');
+
 const logger = require( 'pelias-logger' ).get( 'geonames' );
 
 // use datapath setting from your config file
@@ -9,6 +9,9 @@ const basepath = config.imports.geonames.datapath;
 const sourceURL = config.imports.geonames.sourceURL;
 
 module.exports = function (countryCode) {
+
+  fs.mkdirSync(basepath, { recursive: true });
+
   const urlPrefix = sourceURL || 'http://download.geonames.org/export/dump';
   const remoteFilePath = `${urlPrefix}/${countryCode}.zip`;
   const localFileName = `${basepath}/${countryCode}.zip`;


### PR DESCRIPTION
The Geonames downloader did not ensure the download directory was created before attempting to download data. This caused issues especially with our docker projects, as the directory would generally not exist.

Fixes https://github.com/pelias/geonames/issues/357
Fixes https://github.com/pelias/docker/issues/82