### PR TITLE
Fix Docker build by skipping npm install scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR $WORKDIR
 
 # copy package.json first to prevent npm install being rerun when only code changes
 COPY ./package.json ${WORKDIR}
-RUN npm install
+RUN npm install --ignore-scripts
 
 # Copy code into image
 ADD . $WORKDIR


### PR DESCRIPTION
These scripts will try to run the `downloadMetadata` task before the code actually exists in the Docker image.

We explicitly run that step later, so it's not a problem to skip it during `npm install`