### PR TITLE
Support metadata download durng `npm install`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,15 +12,16 @@ RUN apt-get update && apt-get install -y bzip2 unzip && rm -rf /var/lib/apt/list
 ENV WORKDIR=/code/pelias/geonames
 WORKDIR $WORKDIR
 
+# copy files needed to update metadata, as it's called with NPM install
+COPY ./bin/updateMetadata.js $WORKDIR/bin/updateMetadata.js
+COPY ./lib/tasks/meta.js ./lib/tasks/metafiles.json $WORKDIR/lib/tasks/
+
 # copy package.json first to prevent npm install being rerun when only code changes
 COPY ./package.json ${WORKDIR}
-RUN npm install --ignore-scripts
+RUN npm install
 
 # Copy code into image
 ADD . $WORKDIR
-
-# Explicitly download metadata (it will not be downloaded automatically in noninteractive sessions)
-RUN npm run download_metadata
 
 # run tests
 RUN npm test


### PR DESCRIPTION
It turns out the fix for downloading metadata in the Docker images from https://github.com/pelias/geonames/pull/398 did _not_ work.

We need to allow NPM scripts during `npm install` so that, among other things, better-sqlite3 can install its Node.js bindings.

In the long run, I wonder if we should rethink the entire metadata approach. Surely it makes sense to treat it as part of the regular download process like we do the `inventory.json` file for the WOF download. That would make a lot of things conceptually easier, and remove one of the key "special" parts of this importer, bringing it more in line with all the others.

But for the short term I wanted to fix the issue without making any changes to peoples workflows or any significant code changes.

So this PR adds _just_ enough files to the Docker image before `npm install` is run so that the metadata download will work. We don't want to copy _all_ the code files first: that would make repeated docker builds slower during local development. This should be a decent middle ground that gets things working again.