### PR TITLE
feat(layers): map PCLD feature code to dependency

### DIFF
--- a/lib/streams/layerMappingStream.js
+++ b/lib/streams/layerMappingStream.js
@@ -5,6 +5,8 @@ function featureCodeToLayerDefault(featureCode) {
   switch (featureCode) {
       case 'PCLI':
           return 'country';
+      case 'PCLD':
+          return 'dependency';
       case 'ADM1':
           return 'region';
       case 'ADM2':

--- a/test/streams/layerMappingStreamTest.js
+++ b/test/streams/layerMappingStreamTest.js
@@ -19,6 +19,16 @@ tape('featureCodeToLayer', function(test) {
     t.end();
   });
 
+  test.test('PCLI maps to country', function (t) {
+    t.equal(featureCodeToLayer('PCLI'), 'country', 'Geonames PCLI maps to country layer');
+    t.end();
+  });
+
+  test.test('PCLD maps to dependency', function (t) {
+    t.equal(featureCodeToLayer('PCLD'), 'dependency', 'Geonames PCLD maps to dependency layer');
+    t.end();
+  });
+
   test.test('ADM1 maps to region', function(t) {
     t.equal(featureCodeToLayer('ADM1'), 'region', 'Geonames ADM1 maps to region layer');
     t.end();


### PR DESCRIPTION
Our current deduplication logic prefers https://www.geonames.org/4566967/puerto-rico.html over https://www.geonames.org/4566966/puerto-rico.html

This is likely due to *both* being classified as a 'venue'.

This PR maps the `PCLD` feature code to `dependency` (previously there was no mapping to `dependency`)

<img width="289" alt="Screenshot 2021-11-10 at 15 12 23" src="https://user-images.githubusercontent.com/738069/141128712-6d51c3a1-e6a1-4114-a124-8e040de922fd.png">


```bash
grep PCLD allCountries.txt | cut -f1,2
3573511	Anguilla
661882	Ahvenanmaan Lääni
3573345	Bermuda
3371123	Bouvet Island
1547376	Territory of Cocos (Keeling) Islands
2078138	Territory of Christmas Island
3474414	Falkland Islands
2622320	Faroe Islands
3381670	Guyane
2411586	Gibraltar
3425505	Greenland
3579143	Guadeloupe
3474415	South Georgia and the South Sandwich Islands
4043988	Guam
1547314	Territory of Heard Island and McDonald Islands
1282588	British Indian Ocean Territory
3580718	Cayman Islands
4041468	Commonwealth of the Northern Mariana Islands
3570311	Martinique
3578097	Montserrat
2139685	New Caledonia
2155115	Territory of Norfolk Island
4030656	French Polynesia
3424932	Saint Pierre and Miquelon
4030699	Pitcairn, Henderson, Ducie and Oeno Islands
4566966	Puerto Rico
935317	Reunion
3370751	Saint Helena, Ascension, and Tristan da Cunha
3576916	Turks and Caicos Islands
4031074	Tokelau
5854968	United States Minor Outlying Islands
3577718	British Virgin Islands
4796775	United States Virgin Islands
4034749	Wallis et Futuna
1024031	Mayotte
```