### PR TITLE
feat(layers): map PCLIX feature code to dependency

### DIFF
--- a/lib/streams/layerMappingStream.js
+++ b/lib/streams/layerMappingStream.js
@@ -6,6 +6,7 @@ function featureCodeToLayerDefault(featureCode) {
       case 'PCLI':
           return 'country';
       case 'PCLD':
+      case 'PCLIX':
           return 'dependency';
       case 'ADM1':
           return 'region';

--- a/test/streams/layerMappingStreamTest.js
+++ b/test/streams/layerMappingStreamTest.js
@@ -24,6 +24,11 @@ tape('featureCodeToLayer', function(test) {
     t.end();
   });
 
+  test.test('PCLIX maps to dependency', function (t) {
+    t.equal(featureCodeToLayer('PCLIX'), 'dependency', 'Geonames PCLIX maps to dependency layer');
+    t.end();
+  });
+
   test.test('PCLD maps to dependency', function (t) {
     t.equal(featureCodeToLayer('PCLD'), 'dependency', 'Geonames PCLD maps to dependency layer');
     t.end();


### PR DESCRIPTION
following on from https://github.com/pelias/geonames/pull/402, the PCLIX feature code also maps to `dependency`.

resolves https://github.com/pelias/geonames/issues/48