### PR TITLE
Drop Nodejs 18, use Nodejs 20 docker baseimage

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -7,7 +7,7 @@ jobs:
       matrix:
         os:
           - ubuntu-22.04
-        node-version: [ 18.x, 20.x, 22.x ]
+        node-version: [ 20.x, 22.x ]
     steps:
       - uses: actions/checkout@v4
       - name: 'Install node.js ${{ matrix.node-version }}'


### PR DESCRIPTION
This drops a now EOL Node.js version from our CI, and puts on a shiny new Docker baseimage.

Connects https://github.com/pelias/pelias/issues/985