### PR TITLE
Remove unused apt dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,6 @@ FROM pelias/baseimage
 # ensure data dirs exists
 RUN mkdir -p '/data/geonames'
 
-# downloader apt dependencies
-# note: this is done in one command in order to keep down the size of intermediate containers
-RUN apt-get update && apt-get install -y bzip2 unzip && rm -rf /var/lib/apt/lists/*
-
 # change working dir
 ENV WORKDIR=/code/pelias/geonames
 WORKDIR $WORKDIR


### PR DESCRIPTION
These packages are now installed in the baseimage, so we don't need to install them here.

See https://github.com/pelias/docker-baseimage/pull/37